### PR TITLE
Hotfix: Granular component reloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ export default function (props) {
 }
 ```
 
-The components are wrapped and memoized. When the module receives an update, it tries to detect if the component's content has changed between updates, prompting a remount for the changed component (which allows the ancestor components to retain their lifecycle.).
+The components are wrapped and memoized. When the module receives an update, it replaces the old components from the old module with the new components.
 
 ## Pragma
 
@@ -47,3 +47,16 @@ Or force reload:
 ```js
 /* @refresh reload */
 ```
+
+### `@refresh granular`
+
+By default, components from the old module are replaced with the new ones from the replacement module, which might cause components that hasn't really changed to unmount abruptly.
+
+Adding `@refresh granular` comment pragma in the file allows components to opt-in to granular replacement: If the component has changed *code-wise*, it will be replaced, otherwise, it will be retained, which allows unchanged ancestor components to preserve lifecycles.
+
+The downside of this mode is that local bindings that are part of the module that which the components depends on won't be detected as a change and thus will not trigger a replacement. This also means that the component may be accessing a different instance of that binding (e.g. createContext). This is currently a known limitation.
+
+## Limitations
+
+- Preserving state: The default mode does not allow preserving state through module replacement. `@refresh granular` allows this partially.
+- No HOC support.

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -258,7 +258,13 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
         }
         const decl = path.node.declaration;
         // Check if declaration is FunctionDeclaration
-        if (t.isFunctionDeclaration(decl) && !(decl.generator || decl.async)) {
+        if (
+          t.isFunctionDeclaration(decl)
+          && !(decl.generator || decl.async)
+          // Might be component-like, but the only valid components
+          // have zero or one parameter
+          && decl.params.length < 2
+        ) {
           // Check if the declaration has an identifier, and then check 
           // if the name is component-ish
           if (decl.id && isComponentishName(decl.id.name)) {
@@ -306,6 +312,9 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
               // Check for valid ArrowFunctionExpression
               || (t.isArrowFunctionExpression(init) && !(init.async || init.generator))
             )
+            // Might be component-like, but the only valid components
+            // have zero or one parameter
+            && init.params.length < 2
           ) {
             path.node.init = createHot(
               path,
@@ -328,7 +337,12 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
         }
         const decl = path.node;
         // Check if declaration is FunctionDeclaration
-        if (!(decl.generator || decl.async)) {
+        if (
+          !(decl.generator || decl.async)
+          // Might be component-like, but the only valid components
+          // have zero or one parameter
+          && decl.params.length < 2
+        ) {
           // Check if the declaration has an identifier, and then check 
           // if the name is component-ish
           if (decl.id && isComponentishName(decl.id.name)) {

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -18,6 +18,7 @@ interface State extends babel.PluginPass {
   hooks: ImportHook;
   opts: Options;
   processed: Ref<boolean>;
+  granular: Ref<boolean>;
 }
 
 function isComponentishName(name: string) {
@@ -91,13 +92,16 @@ function createSignature(node: t.Node): string {
 
 function createStandardHot(
   path: babel.NodePath,
-  hooks: ImportHook,
-  opts: Options,
+  state: State,
   HotComponent: t.Identifier,
   rename: t.VariableDeclaration,
 ) {
-  const HotImport = getSolidRefreshIdentifier(hooks, path, opts.bundler || 'standard');
-  const pathToHot = getHotIdentifier(opts.bundler);
+  const HotImport = getSolidRefreshIdentifier(
+    state.hooks,
+    path,
+    state.opts.bundler || 'standard',
+  );
+  const pathToHot = getHotIdentifier(state.opts.bundler);
   const statementPath = getStatementPath(path);
   if (statementPath) {
     statementPath.insertBefore(rename);
@@ -105,25 +109,28 @@ function createStandardHot(
   return t.callExpression(HotImport, [
     HotComponent,
     t.stringLiteral(HotComponent.name),
-    t.stringLiteral(createSignature(rename)),
+    state.granular.value ? t.stringLiteral(createSignature(rename)) : t.identifier('undefined'),
     pathToHot,
   ]);
 }
 
 function createESMHot(
   path: babel.NodePath,
-  hooks: ImportHook,
-  opts: Options,
+  state: State,
   HotComponent: t.Identifier,
   rename: t.VariableDeclaration,
 ) {
-  const HotImport = getSolidRefreshIdentifier(hooks, path, opts.bundler || 'standard');
-  const pathToHot = getHotIdentifier(opts.bundler);
+  const HotImport = getSolidRefreshIdentifier(
+    state.hooks,
+    path,
+    state.opts.bundler || 'standard',
+  );
+  const pathToHot = getHotIdentifier(state.opts.bundler);
   const handlerId = path.scope.generateUidIdentifier("handler");
   const componentId = path.scope.generateUidIdentifier("Component");
   const statementPath = getStatementPath(path);
   if (statementPath) {
-    const registrationMap = createHotMap(hooks, statementPath, '$$registrations');
+    const registrationMap = createHotMap(state.hooks, statementPath, '$$registrations');
     statementPath.insertBefore(rename);
     statementPath.insertBefore(
       t.expressionStatement(
@@ -133,10 +140,16 @@ function createESMHot(
             registrationMap,
             HotComponent,
           ),
-          t.objectExpression([
-            t.objectProperty(t.identifier('component'), HotComponent),
-            t.objectProperty(t.identifier('signature'), t.stringLiteral(createSignature(rename))),
-          ]),
+          t.objectExpression(
+            state.granular.value
+              ? [
+                t.objectProperty(t.identifier('component'), HotComponent),
+                t.objectProperty(t.identifier('signature'), t.stringLiteral(createSignature(rename))),
+              ]
+              : [
+                t.objectProperty(t.identifier('component'), HotComponent),
+              ]
+          ),
         ),
       )
     );
@@ -150,13 +163,16 @@ function createESMHot(
           t.callExpression(HotImport, [
             HotComponent,
             t.stringLiteral(HotComponent.name),
-            t.memberExpression(
-              t.memberExpression(
-                registrationMap,
-                HotComponent,
-              ),
-              t.identifier('signature'),
-            ),
+            state.granular.value
+              ? t.memberExpression(
+                t.memberExpression(
+                  registrationMap,
+                  HotComponent,
+                ),
+                t.identifier('signature'),
+              )
+              : t.identifier('undefined')
+            ,
             t.unaryExpression("!", t.unaryExpression("!", pathToHot))
           ]),
         )
@@ -174,12 +190,11 @@ function createESMHot(
 
 function createHot(
   path: babel.NodePath,
-  hooks: ImportHook,
-  opts: Options,
+  state: State,
   name: t.Identifier | undefined,
   expression: t.Expression,
 ) {
-  if (opts.bundler === "vite") opts.bundler = "esm";
+  if (state.opts.bundler === "vite") state.opts.bundler = "esm";
   const HotComponent = name
     ? path.scope.generateUidIdentifier(`Hot$$${name.name}`)
     : path.scope.generateUidIdentifier('HotComponent');
@@ -189,10 +204,10 @@ function createHot(
       expression,
     ),
   ]);
-  if (opts.bundler === "esm") {
-    return createESMHot(path, hooks, opts, HotComponent, rename);
+  if (state.opts.bundler === "esm") {
+    return createESMHot(path, state, HotComponent, rename);
   }
-  return createStandardHot(path, hooks, opts, HotComponent, rename);
+  return createStandardHot(path, state, HotComponent, rename);
 }
 
 export default function solidRefreshPlugin(): babel.PluginObj<State> {
@@ -203,12 +218,19 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
       this.processed = {
         value: false,
       };
+      this.granular = {
+        value: false,
+      };
     },
     visitor: {
-      Program(path, { opts, processed }) {
+      Program(path, { opts, processed, granular }) {
         const comments = path.hub.file.ast.comments;
         for (let i = 0; i < comments.length; i++) {
           const comment = comments[i].value;
+          if (/^\s*@refresh granular\s*$/.test(comment)) {
+            granular.value = true;
+            return;
+          }
           if (/^\s*@refresh skip\s*$/.test(comment)) {
             processed.value = true;
             return;
@@ -230,8 +252,8 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
           }
         }
       },
-      ExportNamedDeclaration(path, { opts, hooks, processed }) {
-        if (processed.value) {
+      ExportNamedDeclaration(path, state) {
+        if (state.processed.value) {
           return;
         }
         const decl = path.node.declaration;
@@ -247,8 +269,7 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
                   decl.id,
                   createHot(
                     path,
-                    hooks,
-                    opts,
+                    state,
                     decl.id,
                     t.functionExpression(
                       decl.id,
@@ -262,8 +283,8 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
           }
         }
       },
-      VariableDeclarator(path, { opts, hooks, processed }) {
-        if (processed.value) {
+      VariableDeclarator(path, state) {
+        if (state.processed.value) {
           return;
         }
         const grandParentNode = path.parentPath?.parentPath?.node;
@@ -288,16 +309,15 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
           ) {
             path.node.init = createHot(
               path,
-              hooks,
-              opts,
+              state,
               identifier,
               init,
             );
           }
         }
       },
-      FunctionDeclaration(path, { opts, hooks, processed }) {
-        if (processed.value) {
+      FunctionDeclaration(path, state) {
+        if (state.processed.value) {
           return;
         }
         if (!(
@@ -314,8 +334,7 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
           if (decl.id && isComponentishName(decl.id.name)) {
             const replacement = createHot(
               path,
-              hooks,
-              opts,
+              state,
               decl.id,
               t.functionExpression(
                 decl.id,
@@ -345,8 +364,7 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
           ) {
             const replacement = createHot(
               path,
-              hooks,
-              opts,
+              state,
               undefined,
               t.functionExpression(
                 null,

--- a/src/esm.ts
+++ b/src/esm.ts
@@ -39,10 +39,17 @@ export default function hot<P>(
     Comp.setComp = setComp;
     Comp.setSign = setSignature;
     Comp.sign = signature;
-    let c: typeof Comp;
-    Component = new Proxy((props: P) => createMemo(() => (c = comp()) && untrack(() => c(props))), {
-      get(_, property) {
-        return comp()[property];
+    Component = new Proxy((props: P) => (
+      createMemo(() => {
+        const c = comp();
+        if (c) {
+          return untrack(() => c(props));
+        }
+        return undefined;
+      })
+    ), {
+      get(_, property: keyof typeof Comp) {
+        return Comp[property];
       }
     });
   }

--- a/src/standard.ts
+++ b/src/standard.ts
@@ -34,10 +34,17 @@ export default function hot<P>(
       };
     });
     hot.accept();
-    let c: typeof Comp;
-    return new Proxy((props: P) => createMemo(() => (c = comp()) && untrack(() => c(props))), {
-      get(_, property) {
-        return comp()[property];
+    return new Proxy((props: P) => (
+      createMemo(() => {
+        const c = comp();
+        if (c) {
+          return untrack(() => c(props));
+        }
+        return undefined;
+      })
+    ), {
+      get(_, property: keyof typeof Comp) {
+        return Comp[property];
       }
     });
   }

--- a/src/standard.ts
+++ b/src/standard.ts
@@ -15,24 +15,35 @@ interface StandardHot {
 export default function hot<P>(
   Comp: (props: P) => JSX.Element,
   id: string,
-  initialSignature: string,
+  initialSignature: string | undefined,
   hot: StandardHot,
 ) {
   if (hot) {
     const [comp, setComp] = createSignal(Comp);
-    const [sign, setSign] = createSignal(initialSignature);
     const prev = hot.data;
-    if (prev && prev[id] && prev[id].sign() !== initialSignature) {
-      prev[id].setSign(() => initialSignature);
-      prev[id].setComp(() => Comp);
+    if (initialSignature) {
+      const [sign, setSign] = createSignal(initialSignature);
+      if (prev && prev[id] && prev[id].sign() !== initialSignature) {
+        prev[id].setSign(() => initialSignature);
+        prev[id].setComp(() => Comp);
+      }
+      hot.dispose(data => {
+        data[id] = prev ? prev[id] : {
+          setComp,
+          sign,
+          setSign,
+        };
+      });
+    } else {
+      if (prev && prev[id]) {
+        prev[id].setComp(() => Comp);
+      }
+      hot.dispose(data => {
+        data[id] = prev ? prev[id] : {
+          setComp,
+        };
+      });
     }
-    hot.dispose(data => {
-      data[id] = prev ? prev[id] : {
-        setComp,
-        sign,
-        setSign,
-      };
-    });
     hot.accept();
     return new Proxy((props: P) => (
       createMemo(() => {
@@ -44,7 +55,7 @@ export default function hot<P>(
       })
     ), {
       get(_, property: keyof typeof Comp) {
-        return Comp[property];
+        return comp()[property];
       }
     });
   }

--- a/test.js
+++ b/test.js
@@ -8,16 +8,10 @@ const plugin = require('./babel');
 
 
 
-
-
-
 babel.transformAsync(`
-// @refresh reload
-export const Foo = () => <h1>Hello Foo</h1>;
-export const Bar = () => <h1>Hello Bar</h1>;
-
-export default function (props) {
-  return <h1>Hello {props.message}</h1>;
+// @refresh granular
+function Foo() {
+  return <h1>{foo} {bar} {baz}</h1>
 }
 `, {
   plugins: [


### PR DESCRIPTION
- Granular component reloading is now disabled by default. Users can opt-in through `@refresh granular` on a per-file basis.
- `esm` and `standard` can now accept undefined signatures. When undefined, it opts-out of signature checks.