### PR TITLE
wrap component for HMR only if it went through devComponent

### DIFF
--- a/src/create-proxy.ts
+++ b/src/create-proxy.ts
@@ -1,4 +1,4 @@
-import { JSX, createMemo, untrack } from 'solid-js';
+import { JSX, createMemo, untrack, $HMRCOMP } from 'solid-js';
 
 interface BaseComponent<P> {
   (props: P): JSX.Element;
@@ -7,15 +7,20 @@ interface BaseComponent<P> {
 export default function createProxy<C extends BaseComponent<P>, P>(
   source: () => C,
 ): (props: P) => JSX.Element {
-  return new Proxy((props: P) => (
-    createMemo(() => {
-      const c = source();
-      if (c) {
-        return untrack(() => c(props));
-      }
-      return undefined;
-    })
-  ), {
+  return new Proxy(function hmrCompWrapper(props: P, ...rest) {
+    const s = source();
+    if (!s || $HMRCOMP in s) {
+      return createMemo(() => {
+        const c = source();
+        if (c) {
+          return untrack(() => c(props));
+        }
+        return undefined;
+      });
+    }
+    // no $HMRCOMP means it did not go through devComponent so source() is a regular function, not a component
+    return s.call(this, props, ...rest);
+  }, {
     get(_, property: keyof C) {
       return source()[property];
     },

--- a/src/create-proxy.ts
+++ b/src/create-proxy.ts
@@ -1,4 +1,4 @@
-import { JSX, createMemo, untrack, $HMRCOMP } from 'solid-js';
+import { JSX, createMemo, untrack, $DEVCOMP } from 'solid-js';
 
 interface BaseComponent<P> {
   (props: P): JSX.Element;
@@ -9,7 +9,7 @@ export default function createProxy<C extends BaseComponent<P>, P>(
 ): (props: P) => JSX.Element {
   return new Proxy(function hmrCompWrapper(props: P, ...rest) {
     const s = source();
-    if (!s || $HMRCOMP in s) {
+    if (!s || $DEVCOMP in s) {
       return createMemo(() => {
         const c = source();
         if (c) {
@@ -18,7 +18,7 @@ export default function createProxy<C extends BaseComponent<P>, P>(
         return undefined;
       });
     }
-    // no $HMRCOMP means it did not go through devComponent so source() is a regular function, not a component
+    // no $DEVCOMP means it did not go through devComponent so source() is a regular function, not a component
     return s.call(this, props, ...rest);
   }, {
     get(_, property: keyof C) {


### PR DESCRIPTION

I noticed that solid web site has two issues with the new (0.3) solid-refresh:

First, the [AppData](https://github.com/solidjs/solid-site/blob/master/src/App.data.tsx#L35) gets wrapped, although it's not a component at all.

Second, [this code in ScrollShadow](https://github.com/solidjs/solid-site/blob/master/src/components/ScrollShadow/ScrollShadow.tsx#L25) expects the result of Sentinel component to be a DOM node, and fails later with `TypeError: Failed to execute 'appendChild' on 'Node': parameter 1 is not of type 'Node'` because the result is actually a memo created in `createProxy()` in the solid-refresh code.

This is the fix for the first one -  I propose to add a special property (`$HMRCOMP` symbol key) to all components in the `devComponent` code in solid.js, so that only the functions that went through `devComponent()` will be wrapped in a memo.


There's [corresponding PR](https://github.com/solidjs/solid/pull/780) in the solid repo that assigns `$HMRCOMP` key in `devComponent()` in signal.ts.

