### PR TITLE
Warn and decline if not using Solid dev build

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ Requires the use of [`@snowpack/plugin-babel`](https://www.npmjs.com/package/@sn
 * [`wmr`](https://wmr.dev/) - SolidJS is yet to be supported or isn't clear yet. It will use the same config as Snowpack.
 * [`rollup-plugin-hot`](https://github.com/rixo/rollup-plugin-hot) - The library uses almost an ESM HMR-like API however it behaves the same way as Parcel. Supporting this library is still unclear.
 
+In any case, your build system needs to support conditional exports and have
+the `development` condition set.
+
 ## How it works
 
 The babel plugin will transform components with matching Pascal-cased names (indicating that they are components). This detection is supported in variable declarations, function declarations and named exports:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solid-refresh",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "solid-refresh",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.16.0",
@@ -21,12 +21,12 @@
         "@types/jest": "^27.0.3",
         "jest": "^27.4.3",
         "rollup": "^2.52.1",
-        "solid-js": "^1.0.0",
+        "solid-js": "^1.3.0",
         "ts-jest": "^27.1.0",
         "typescript": "^4.5.2"
       },
       "peerDependencies": {
-        "solid-js": "^1.0.0"
+        "solid-js": "^1.3.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5302,11 +5302,10 @@
       }
     },
     "node_modules/solid-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.0.0.tgz",
-      "integrity": "sha512-5huTDVyMqZSjg5Sa4mwl15feK4il1cE68n4weL5NYGC8lX2wiDlcHhBdSB8trKgaJ50Q9/pwtLrQngFaDC+5Tw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.3.3.tgz",
+      "integrity": "sha512-0pyHpLZIgQDI1Z+MgxXQRPY10dhXfKJdptb4UCJQ9ArQOLq2gtFA1acEsvSAtPMVdqQ8bqj68FOTXLpz6hm2Mg==",
+      "dev": true
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -9914,9 +9913,9 @@
       "dev": true
     },
     "solid-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.0.0.tgz",
-      "integrity": "sha512-5huTDVyMqZSjg5Sa4mwl15feK4il1cE68n4weL5NYGC8lX2wiDlcHhBdSB8trKgaJ50Q9/pwtLrQngFaDC+5Tw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.3.3.tgz",
+      "integrity": "sha512-0pyHpLZIgQDI1Z+MgxXQRPY10dhXfKJdptb4UCJQ9ArQOLq2gtFA1acEsvSAtPMVdqQ8bqj68FOTXLpz6hm2Mg==",
       "dev": true
     },
     "source-map": {

--- a/src/standard.ts
+++ b/src/standard.ts
@@ -1,4 +1,4 @@
-import { createSignal, JSX } from "solid-js";
+import { createSignal, JSX, DEV } from "solid-js";
 import createProxy from "./create-proxy";
 import isListUpdated from "./is-list-updated";
 
@@ -23,11 +23,19 @@ interface HotSignature<P> {
   dependencies?: any[];
 }
 
+let warned = false;
+
 export default function hot<P>(
   { component: Comp, id, signature, dependencies }: HotSignature<P>,
   hot: StandardHot,
 ) {
-  if (hot) {
+  if (!(DEV && Object.keys(DEV).length)) {
+    if (!warned) {
+      console.warn("To use solid-refresh, you need to use the dev build of SolidJS. Make sure your build system supports package.json conditional exports and has the 'development' condition turned on.");
+      warned = true;
+    }
+    if (hot && hot.decline) hot.decline();
+  } else if (hot) {
     const [comp, setComp] = createSignal(Comp);
     const prev = hot.data;
     // Check if there's previous data


### PR DESCRIPTION
Implements [Ryan's suggestion](https://discord.com/channels/722131463138705510/843551011825909760/931666654457397369) to refresh the page (`module.hot.decline()`) if Solid isn't in dev mode. Also warns (once) in this case. Also added a mention in the README.

Possible issues for discussion:
* I wasn't sure the best way to detect dev mode. On the client non-dev, `DEV` is undefined; but on the server non-dev, `DEV` is `{}`. I opted to check for both cases, but as this only runs on the client, maybe checking `!DEV` is enough...
* I only implemented (and tested in Meteor) within the `standard` version, as that's the only type I'm familiar with. It would be nice to add to the `esm` version too.