### PR TITLE
add identifiable name to internal memo in createProxy

### DIFF
--- a/src/create-proxy.ts
+++ b/src/create-proxy.ts
@@ -1,4 +1,4 @@
-import { JSX, createMemo, untrack, $DEVCOMP } from 'solid-js';
+import { JSX, createMemo, untrack, $DEVCOMP, createUniqueId } from 'solid-js';
 
 interface BaseComponent<P> {
   (props: P): JSX.Element;
@@ -16,7 +16,7 @@ export default function createProxy<C extends BaseComponent<P>, P>(
           return untrack(() => c(props));
         }
         return undefined;
-      });
+      }, undefined, { name: 'sr-' + createUniqueId() });
     }
     // no $DEVCOMP means it did not go through devComponent so source() is a regular function, not a component
     return s.call(this, props, ...rest);


### PR DESCRIPTION
adds custom computation name to `createMemo` in the `createProxy` function. This is so that memo could be identified as separate from normal application in the owner tree.
The `sr-` is from solid-refresh, but it could be anything else.

Edit: Found a workaround so it's not really needed, but will leave this open for now as I think that giving names to internal computations might be beneficial in identifying what's users and what's not.