### PR TITLE
Add note about needed webpack devServer config

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,18 @@ If you're using strict ESM:
 {
   "env": {
     "development": {
-      "plugins": ["solid-refresh/babel", { "bundler": "webpack5" }]
+      "plugins": [["solid-refresh/babel", { "bundler": "webpack5" }]]
     }
   }
+}
+```
+
+In your webpack config, be sure to have the following options:
+
+```js
+devServer: {
+  liveReload: false,
+  hot: true,
 }
 ```
 


### PR DESCRIPTION
I spend hours searching why it always reloaded the page and not patching the component with my webpack setup.
I hope this will be useful to the next person trying to use hmr with webpack.
The important part is the two options
```
devServer: {
  liveReload: false,
  hot: true,
}
```

and also double brackets in `.babelrc`. When you give an additional option to a plugin, it needs to be an array.