### PR TITLE
Chore: formatting, fix types and missing dev deps

### DIFF
--- a/babel.js
+++ b/babel.js
@@ -30,7 +30,7 @@ var generator__default = /*#__PURE__*/_interopDefaultLegacy(generator);
 var crypto__default = /*#__PURE__*/_interopDefaultLegacy(crypto);
 
 function isComponentishName(name) {
-    return typeof name === 'string' && name[0] >= 'A' && name[0] <= 'Z';
+    return typeof name === "string" && name[0] >= "A" && name[0] <= "Z";
 }
 function getModuleIdentifier(hooks, path, name, mod) {
     const target = `${mod}[${name}]`;
@@ -43,22 +43,22 @@ function getModuleIdentifier(hooks, path, name, mod) {
     return newID;
 }
 function getSolidRefreshIdentifier(hooks, path, name) {
-    return getModuleIdentifier(hooks, path, name, 'solid-refresh');
+    return getModuleIdentifier(hooks, path, name, "solid-refresh");
 }
 function isESMHMR(bundler) {
     // The currently known ESM HMR implementations
     // esm - the original ESM HMR Spec
     // vite - Vite's implementation
-    return bundler === 'esm' || bundler === 'vite';
+    return bundler === "esm" || bundler === "vite";
 }
 function getHotIdentifier(bundler) {
     // vite/esm uses `import.meta.hot`
     if (isESMHMR(bundler)) {
-        return t__namespace.memberExpression(t__namespace.memberExpression(t__namespace.identifier('import'), t__namespace.identifier('meta')), t__namespace.identifier('hot'));
+        return t__namespace.memberExpression(t__namespace.memberExpression(t__namespace.identifier("import"), t__namespace.identifier("meta")), t__namespace.identifier("hot"));
     }
     // webpack 5 uses `import.meta.webpackHot`
-    if (bundler === 'webpack5') {
-        return t__namespace.memberExpression(t__namespace.memberExpression(t__namespace.identifier('import'), t__namespace.identifier('meta')), t__namespace.identifier('webpackHot'));
+    if (bundler === "webpack5") {
+        return t__namespace.memberExpression(t__namespace.memberExpression(t__namespace.identifier("import"), t__namespace.identifier("meta")), t__namespace.identifier("webpackHot"));
     }
     // `module.hot` is the default.
     return t__namespace.memberExpression(t__namespace.identifier("module"), t__namespace.identifier("hot"));
@@ -78,13 +78,13 @@ function createHotMap(hooks, path, name) {
         return current;
     }
     const newID = t__namespace.identifier(name);
-    path.insertBefore(t__namespace.exportNamedDeclaration(t__namespace.variableDeclaration('const', [t__namespace.variableDeclarator(newID, t__namespace.objectExpression([]))])));
+    path.insertBefore(t__namespace.exportNamedDeclaration(t__namespace.variableDeclaration("const", [t__namespace.variableDeclarator(newID, t__namespace.objectExpression([]))])));
     hooks.set(name, newID);
     return newID;
 }
 function createSignatureValue(node) {
     const code = generator__default["default"](node);
-    const result = crypto__default["default"].createHash('sha256').update(code.code).digest('base64');
+    const result = crypto__default["default"].createHash("sha256").update(code.code).digest("base64");
     return result;
 }
 function isForeignBinding(source, current, name) {
@@ -102,28 +102,27 @@ function isForeignBinding(source, current, name) {
 function createHotSignature(component, sign, deps) {
     if (sign && deps) {
         return t__namespace.objectExpression([
-            t__namespace.objectProperty(t__namespace.identifier('component'), component),
-            t__namespace.objectProperty(t__namespace.identifier('id'), t__namespace.stringLiteral(component.name)),
-            t__namespace.objectProperty(t__namespace.identifier('signature'), sign),
-            t__namespace.objectProperty(t__namespace.identifier('dependencies'), t__namespace.arrayExpression(deps)),
+            t__namespace.objectProperty(t__namespace.identifier("component"), component),
+            t__namespace.objectProperty(t__namespace.identifier("id"), t__namespace.stringLiteral(component.name)),
+            t__namespace.objectProperty(t__namespace.identifier("signature"), sign),
+            t__namespace.objectProperty(t__namespace.identifier("dependencies"), t__namespace.arrayExpression(deps))
         ]);
     }
     return t__namespace.objectExpression([
-        t__namespace.objectProperty(t__namespace.identifier('component'), component),
-        t__namespace.objectProperty(t__namespace.identifier('id'), t__namespace.stringLiteral(component.name)),
+        t__namespace.objectProperty(t__namespace.identifier("component"), component),
+        t__namespace.objectProperty(t__namespace.identifier("id"), t__namespace.stringLiteral(component.name))
     ]);
 }
 function getBindings(path) {
     const identifiers = new Set();
     path.traverse({
         Expression(p) {
-            if (t__namespace.isIdentifier(p.node)
-                && !t__namespace.isTypeScript(p.parentPath.node)
-                && isForeignBinding(path, p, p.node.name)) {
+            if (t__namespace.isIdentifier(p.node) &&
+                !t__namespace.isTypeScript(p.parentPath.node) &&
+                isForeignBinding(path, p, p.node.name)) {
                 identifiers.add(p.node.name);
             }
-            if (t__namespace.isJSXElement(p.node)
-                && t__namespace.isJSXMemberExpression(p.node.openingElement.name)) {
+            if (t__namespace.isJSXElement(p.node) && t__namespace.isJSXMemberExpression(p.node.openingElement.name)) {
                 let base = p.node.openingElement.name;
                 while (t__namespace.isJSXMemberExpression(base)) {
                     base = base.object;
@@ -134,10 +133,10 @@ function getBindings(path) {
             }
         }
     });
-    return [...identifiers].map((value) => t__namespace.identifier(value));
+    return [...identifiers].map(value => t__namespace.identifier(value));
 }
 function createStandardHot(path, state, HotComponent, rename) {
-    const HotImport = getSolidRefreshIdentifier(state.hooks, path, 'standard');
+    const HotImport = getSolidRefreshIdentifier(state.hooks, path, "standard");
     const pathToHot = getHotIdentifier(state.opts.bundler);
     const statementPath = getStatementPath(path);
     if (statementPath) {
@@ -145,41 +144,37 @@ function createStandardHot(path, state, HotComponent, rename) {
     }
     return t__namespace.callExpression(HotImport, [
         createHotSignature(HotComponent, state.granular.value ? t__namespace.stringLiteral(createSignatureValue(rename)) : undefined, state.granular.value ? getBindings(path) : undefined),
-        pathToHot,
+        pathToHot
     ]);
 }
 function createESMHot(path, state, HotComponent, rename) {
-    const HotImport = getSolidRefreshIdentifier(state.hooks, path, 'esm');
+    const HotImport = getSolidRefreshIdentifier(state.hooks, path, "esm");
     const pathToHot = getHotIdentifier(state.opts.bundler);
     const handlerId = path.scope.generateUidIdentifier("handler");
     const componentId = path.scope.generateUidIdentifier("Component");
     const statementPath = getStatementPath(path);
     if (statementPath) {
-        const registrationMap = createHotMap(state.hooks, statementPath, '$$registrations');
+        const registrationMap = createHotMap(state.hooks, statementPath, "$$registrations");
         statementPath.insertBefore(rename);
-        statementPath.insertBefore(t__namespace.expressionStatement(t__namespace.assignmentExpression('=', t__namespace.memberExpression(registrationMap, HotComponent), createHotSignature(HotComponent, state.granular.value
-            ? t__namespace.stringLiteral(createSignatureValue(rename))
-            : undefined, state.granular.value
-            ? getBindings(path)
-            : undefined))));
+        statementPath.insertBefore(t__namespace.expressionStatement(t__namespace.assignmentExpression("=", t__namespace.memberExpression(registrationMap, HotComponent), createHotSignature(HotComponent, state.granular.value ? t__namespace.stringLiteral(createSignatureValue(rename)) : undefined, state.granular.value ? getBindings(path) : undefined))));
         statementPath.insertBefore(t__namespace.variableDeclaration("const", [
             t__namespace.variableDeclarator(t__namespace.objectPattern([
-                t__namespace.objectProperty(t__namespace.identifier('handler'), handlerId, false, true),
-                t__namespace.objectProperty(t__namespace.identifier('Component'), componentId, false, true)
+                t__namespace.objectProperty(t__namespace.identifier("handler"), handlerId, false, true),
+                t__namespace.objectProperty(t__namespace.identifier("Component"), componentId, false, true)
             ]), t__namespace.callExpression(HotImport, [
                 t__namespace.memberExpression(registrationMap, HotComponent),
-                t__namespace.unaryExpression("!", t__namespace.unaryExpression("!", pathToHot)),
+                t__namespace.unaryExpression("!", t__namespace.unaryExpression("!", pathToHot))
             ]))
         ]));
-        const mod = path.scope.generateUidIdentifier('mod');
+        const mod = path.scope.generateUidIdentifier("mod");
         statementPath.insertBefore(t__namespace.ifStatement(pathToHot, t__namespace.expressionStatement(t__namespace.callExpression(t__namespace.memberExpression(pathToHot, t__namespace.identifier("accept")), [
             t__namespace.arrowFunctionExpression([mod], t__namespace.blockStatement([
-                t__namespace.expressionStatement(t__namespace.logicalExpression('&&', t__namespace.callExpression(handlerId, [
+                t__namespace.expressionStatement(t__namespace.logicalExpression("&&", t__namespace.callExpression(handlerId, [
                     // Vite interprets this differently
-                    state.opts.bundler === 'esm'
-                        ? t__namespace.memberExpression(mod, t__namespace.identifier('module'))
+                    state.opts.bundler === "esm"
+                        ? t__namespace.memberExpression(mod, t__namespace.identifier("module"))
                         : mod
-                ]), t__namespace.callExpression(t__namespace.memberExpression(pathToHot, t__namespace.identifier("invalidate")), []))),
+                ]), t__namespace.callExpression(t__namespace.memberExpression(pathToHot, t__namespace.identifier("invalidate")), [])))
             ]))
         ]))));
     }
@@ -188,19 +183,17 @@ function createESMHot(path, state, HotComponent, rename) {
 function createHot(path, state, name, expression) {
     const HotComponent = name
         ? path.scope.generateUidIdentifier(`Hot$$${name.name}`)
-        : path.scope.generateUidIdentifier('HotComponent');
-    const rename = t__namespace.variableDeclaration("const", [
-        t__namespace.variableDeclarator(HotComponent, expression),
-    ]);
+        : path.scope.generateUidIdentifier("HotComponent");
+    const rename = t__namespace.variableDeclaration("const", [t__namespace.variableDeclarator(HotComponent, expression)]);
     if (isESMHMR(state.opts.bundler)) {
         return createESMHot(path, state, HotComponent, rename);
     }
     return createStandardHot(path, state, HotComponent, rename);
 }
-const SOURCE_MODULE = 'solid-js/web';
+const SOURCE_MODULE = "solid-js/web";
 function isValidSpecifier(specifier, keyword) {
-    return ((t__namespace.isIdentifier(specifier.imported) && specifier.imported.name === keyword)
-        || (t__namespace.isStringLiteral(specifier.imported) && specifier.imported.value === keyword));
+    return ((t__namespace.isIdentifier(specifier.imported) && specifier.imported.name === keyword) ||
+        (t__namespace.isStringLiteral(specifier.imported) && specifier.imported.value === keyword));
 }
 function captureValidIdentifiers(path) {
     const validIdentifiers = new Set();
@@ -209,9 +202,8 @@ function captureValidIdentifiers(path) {
             if (p.node.source.value === SOURCE_MODULE) {
                 for (let i = 0, len = p.node.specifiers.length; i < len; i += 1) {
                     const specifier = p.node.specifiers[i];
-                    if (t__namespace.isImportSpecifier(specifier)
-                        && (isValidSpecifier(specifier, 'render')
-                            || isValidSpecifier(specifier, 'hydrate'))) {
+                    if (t__namespace.isImportSpecifier(specifier) &&
+                        (isValidSpecifier(specifier, "render") || isValidSpecifier(specifier, "hydrate"))) {
                         validIdentifiers.add(specifier.local);
                     }
                 }
@@ -241,14 +233,14 @@ function isValidCallee(path, { callee }, validIdentifiers, validNamespaces) {
         const binding = path.scope.getBinding(callee.name);
         return binding && validIdentifiers.has(binding.identifier);
     }
-    if (t__namespace.isMemberExpression(callee)
-        && !callee.computed
-        && t__namespace.isIdentifier(callee.object)
-        && t__namespace.isIdentifier(callee.property)) {
+    if (t__namespace.isMemberExpression(callee) &&
+        !callee.computed &&
+        t__namespace.isIdentifier(callee.object) &&
+        t__namespace.isIdentifier(callee.property)) {
         const binding = path.scope.getBinding(callee.object.name);
-        return (binding
-            && validNamespaces.has(binding.identifier)
-            && (callee.property.name === 'render' || callee.property.name === 'hydrate'));
+        return (binding &&
+            validNamespaces.has(binding.identifier) &&
+            (callee.property.name === "render" || callee.property.name === "hydrate"));
     }
     return false;
 }
@@ -270,79 +262,76 @@ function fixRenderCalls(path, opts) {
     const validNamespaces = captureValidNamespaces(path);
     path.traverse({
         ExpressionStatement(p) {
-            if (t__namespace.isCallExpression(p.node.expression)
-                && checkValidRenderCall(p)
-                && isValidCallee(p, p.node.expression, validIdentifiers, validNamespaces)) {
+            if (t__namespace.isCallExpression(p.node.expression) &&
+                checkValidRenderCall(p) &&
+                isValidCallee(p, p.node.expression, validIdentifiers, validNamespaces)) {
                 // Replace with variable declaration
                 const id = p.scope.generateUidIdentifier("cleanup");
-                p.replaceWith(t__namespace.variableDeclaration('const', [
-                    t__namespace.variableDeclarator(id, p.node.expression),
-                ]));
+                p.replaceWith(t__namespace.variableDeclaration("const", [t__namespace.variableDeclarator(id, p.node.expression)]));
                 const pathToHot = getHotIdentifier(opts.bundler);
-                p.insertAfter(t__namespace.ifStatement(pathToHot, t__namespace.expressionStatement(t__namespace.callExpression(t__namespace.memberExpression(pathToHot, t__namespace.identifier('dispose')), [id]))));
+                p.insertAfter(t__namespace.ifStatement(pathToHot, t__namespace.expressionStatement(t__namespace.callExpression(t__namespace.memberExpression(pathToHot, t__namespace.identifier("dispose")), [id]))));
                 p.skip();
             }
-        },
+        }
     });
-}
-function createDevWarning(hooks, path) {
-    const id = getModuleIdentifier(hooks, path, 'DEV', 'solid-refresh');
-    path.pushContainer('body', t__namespace.ifStatement(
-    // !(DEV && Object.keys(DEV).length)
-    t__namespace.unaryExpression('!', t__namespace.logicalExpression('&&', id, t__namespace.memberExpression(t__namespace.callExpression(t__namespace.memberExpression(t__namespace.identifier('Object'), t__namespace.identifier('keys')), [id]), t__namespace.identifier('length')))), t__namespace.expressionStatement(t__namespace.callExpression(t__namespace.memberExpression(t__namespace.identifier('console'), t__namespace.identifier('warn')), [
-        t__namespace.stringLiteral('To use solid-refresh, you need to use the dev build of SolidJS. Make sure your build system supports package.json conditional exports and has the \'development\' condition turned on.'),
-    ]))));
 }
 function getHMRDecline(opts, pathToHot) {
     if (isESMHMR(opts.bundler)) {
-        return (t__namespace.ifStatement(pathToHot, t__namespace.expressionStatement(t__namespace.callExpression(t__namespace.memberExpression(pathToHot, t__namespace.identifier("decline")), []))));
+        return t__namespace.ifStatement(pathToHot, t__namespace.expressionStatement(t__namespace.callExpression(t__namespace.memberExpression(pathToHot, t__namespace.identifier("decline")), [])));
     }
-    if (opts.bundler === 'webpack5') {
-        return (t__namespace.ifStatement(pathToHot, t__namespace.expressionStatement(t__namespace.callExpression(t__namespace.memberExpression(pathToHot, t__namespace.identifier("decline")), []))));
+    if (opts.bundler === "webpack5") {
+        return t__namespace.ifStatement(pathToHot, t__namespace.expressionStatement(t__namespace.callExpression(t__namespace.memberExpression(pathToHot, t__namespace.identifier("decline")), [])));
     }
-    return (t__namespace.ifStatement(pathToHot, t__namespace.expressionStatement(t__namespace.conditionalExpression(t__namespace.memberExpression(pathToHot, t__namespace.identifier("decline")), t__namespace.callExpression(t__namespace.memberExpression(pathToHot, t__namespace.identifier("decline")), []), t__namespace.callExpression(t__namespace.memberExpression(t__namespace.memberExpression(t__namespace.identifier("window"), t__namespace.identifier("location")), t__namespace.identifier("reload")), [])))));
+    return t__namespace.ifStatement(pathToHot, t__namespace.expressionStatement(t__namespace.conditionalExpression(t__namespace.memberExpression(pathToHot, t__namespace.identifier("decline")), t__namespace.callExpression(t__namespace.memberExpression(pathToHot, t__namespace.identifier("decline")), []), t__namespace.callExpression(t__namespace.memberExpression(t__namespace.memberExpression(t__namespace.identifier("window"), t__namespace.identifier("location")), t__namespace.identifier("reload")), []))));
+}
+function createDevWarning(path, hooks, opts) {
+    path.pushContainer("body", t__namespace.ifStatement(t__namespace.callExpression(getModuleIdentifier(hooks, path, "shouldWarnAndDecline", "solid-refresh"), []), getHMRDecline(opts, getHotIdentifier(opts.bundler))));
 }
 function solidRefreshPlugin() {
     return {
-        name: 'Solid Refresh',
+        name: "Solid Refresh",
         pre() {
             this.hooks = new Map();
             this.processed = {
-                value: false,
+                value: false
             };
             this.granular = {
-                value: false,
+                value: false
             };
         },
         visitor: {
             Program(path, { file, opts, processed, granular, hooks }) {
                 var _a;
                 let shouldReload = false;
+                let shouldSkip = false;
                 const comments = file.ast.comments;
                 if (comments) {
                     for (let i = 0; i < comments.length; i++) {
                         const comment = comments[i].value;
                         if (/^\s*@refresh granular\s*$/.test(comment)) {
                             granular.value = true;
-                            return;
+                            break;
                         }
                         if (/^\s*@refresh skip\s*$/.test(comment)) {
                             processed.value = true;
-                            return;
+                            shouldSkip = true;
+                            break;
                         }
                         if (/^\s*@refresh reload\s*$/.test(comment)) {
                             processed.value = true;
                             shouldReload = true;
                             const pathToHot = getHotIdentifier(opts.bundler);
-                            path.pushContainer('body', getHMRDecline(opts, pathToHot));
-                            return;
+                            path.pushContainer("body", getHMRDecline(opts, pathToHot));
+                            break;
                         }
                     }
                 }
                 if (!shouldReload && ((_a = opts.fixRender) !== null && _a !== void 0 ? _a : true)) {
                     fixRenderCalls(path, opts);
                 }
-                createDevWarning(hooks, path);
+                if (!shouldSkip) {
+                    createDevWarning(path, hooks, opts);
+                }
             },
             ExportNamedDeclaration(path, state) {
                 if (state.processed.value) {
@@ -350,15 +339,15 @@ function solidRefreshPlugin() {
                 }
                 const decl = path.node.declaration;
                 // Check if declaration is FunctionDeclaration
-                if (t__namespace.isFunctionDeclaration(decl)
-                    && !(decl.generator || decl.async)
+                if (t__namespace.isFunctionDeclaration(decl) &&
+                    !(decl.generator || decl.async) &&
                     // Might be component-like, but the only valid components
                     // have zero or one parameter
-                    && decl.params.length < 2) {
-                    // Check if the declaration has an identifier, and then check 
+                    decl.params.length < 2) {
+                    // Check if the declaration has an identifier, and then check
                     // if the name is component-ish
                     if (decl.id && isComponentishName(decl.id.name)) {
-                        path.node.declaration = t__namespace.variableDeclaration('const', [
+                        path.node.declaration = t__namespace.variableDeclaration("const", [
                             t__namespace.variableDeclarator(decl.id, createHot(path, state, decl.id, t__namespace.functionExpression(decl.id, decl.params, decl.body)))
                         ]);
                     }
@@ -372,20 +361,18 @@ function solidRefreshPlugin() {
                 const grandParentNode = (_b = (_a = path.parentPath) === null || _a === void 0 ? void 0 : _a.parentPath) === null || _b === void 0 ? void 0 : _b.node;
                 // Check if the parent of the VariableDeclaration
                 // is either a Program or an ExportNamedDeclaration
-                if (t__namespace.isProgram(grandParentNode)
-                    || t__namespace.isExportNamedDeclaration(grandParentNode)) {
+                if (t__namespace.isProgram(grandParentNode) || t__namespace.isExportNamedDeclaration(grandParentNode)) {
                     const identifier = path.node.id;
                     const init = path.node.init;
-                    if (t__namespace.isIdentifier(identifier)
-                        && isComponentishName(identifier.name)
-                        && (
+                    if (t__namespace.isIdentifier(identifier) &&
+                        isComponentishName(identifier.name) &&
                         // Check for valid FunctionExpression
-                        (t__namespace.isFunctionExpression(init) && !(init.async || init.generator))
+                        ((t__namespace.isFunctionExpression(init) && !(init.async || init.generator)) ||
                             // Check for valid ArrowFunctionExpression
-                            || (t__namespace.isArrowFunctionExpression(init) && !(init.async || init.generator)))
+                            (t__namespace.isArrowFunctionExpression(init) && !(init.async || init.generator))) &&
                         // Might be component-like, but the only valid components
                         // have zero or one parameter
-                        && init.params.length < 2) {
+                        init.params.length < 2) {
                         path.node.init = createHot(path, state, identifier, init);
                     }
                 }
@@ -394,17 +381,16 @@ function solidRefreshPlugin() {
                 if (state.processed.value) {
                     return;
                 }
-                if (!(t__namespace.isProgram(path.parentPath.node)
-                    || t__namespace.isExportDefaultDeclaration(path.parentPath.node))) {
+                if (!(t__namespace.isProgram(path.parentPath.node) || t__namespace.isExportDefaultDeclaration(path.parentPath.node))) {
                     return;
                 }
                 const decl = path.node;
                 // Check if declaration is FunctionDeclaration
-                if (!(decl.generator || decl.async)
+                if (!(decl.generator || decl.async) &&
                     // Might be component-like, but the only valid components
                     // have zero or one parameter
-                    && decl.params.length < 2) {
-                    // Check if the declaration has an identifier, and then check 
+                    decl.params.length < 2) {
+                    // Check if the declaration has an identifier, and then check
                     // if the name is component-ish
                     if (decl.id && isComponentishName(decl.id.name)) {
                         const replacement = createHot(path, state, decl.id, t__namespace.functionExpression(decl.id, decl.params, decl.body));
@@ -412,22 +398,20 @@ function solidRefreshPlugin() {
                             path.replaceWith(replacement);
                         }
                         else {
-                            path.replaceWith(t__namespace.variableDeclaration('var', [
-                                t__namespace.variableDeclarator(decl.id, replacement),
-                            ]));
+                            path.replaceWith(t__namespace.variableDeclaration("var", [t__namespace.variableDeclarator(decl.id, replacement)]));
                         }
                     }
-                    else if (!decl.id
-                        && decl.params.length === 1
-                        && t__namespace.isIdentifier(decl.params[0])
-                        && decl.params[0].name === 'props'
-                        && t__namespace.isExportDefaultDeclaration(path.parentPath.node)) {
+                    else if (!decl.id &&
+                        decl.params.length === 1 &&
+                        t__namespace.isIdentifier(decl.params[0]) &&
+                        decl.params[0].name === "props" &&
+                        t__namespace.isExportDefaultDeclaration(path.parentPath.node)) {
                         const replacement = createHot(path, state, undefined, t__namespace.functionExpression(null, decl.params, decl.body));
                         path.replaceWith(replacement);
                     }
                 }
             }
-        },
+        }
     };
 }
 

--- a/package.json
+++ b/package.json
@@ -25,15 +25,21 @@
   "scripts": {
     "build": "rollup -c",
     "test": "vitest",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "format": "prettier -w \"{tests,src}/**/*.{js,ts}\""
   },
   "devDependencies": {
     "@babel/core": "^7.18.5",
+    "@babel/generator": "^7.18.7",
     "@rollup/plugin-node-resolve": "13.3.0",
     "@rollup/plugin-typescript": "^8.3.3",
     "@types/babel__core": "^7.1.19",
+    "@types/babel__generator": "^7.6.4",
+    "@types/node": "^18.7.23",
+    "prettier": "^2.7.1",
     "rollup": "^2.75.7",
     "solid-js": "^1.4.4",
+    "tslib": "^2.4.0",
     "typescript": "^4.7.4",
     "vitest": "^0.16.0"
   },
@@ -41,7 +47,6 @@
     "solid-js": "^1.3"
   },
   "dependencies": {
-    "@babel/generator": "^7.18.2",
     "@babel/helper-module-imports": "^7.16.7",
     "@babel/types": "^7.18.4"
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.18.5",
-    "@babel/generator": "^7.18.7",
     "@rollup/plugin-node-resolve": "13.3.0",
     "@rollup/plugin-typescript": "^8.3.3",
     "@types/babel__core": "^7.1.19",
@@ -47,6 +46,7 @@
     "solid-js": "^1.3"
   },
   "dependencies": {
+    "@babel/generator": "^7.18.7",
     "@babel/helper-module-imports": "^7.16.7",
     "@babel/types": "^7.18.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,29 +2,37 @@ lockfileVersion: 5.4
 
 specifiers:
   '@babel/core': ^7.18.5
-  '@babel/generator': ^7.18.2
+  '@babel/generator': ^7.18.7
   '@babel/helper-module-imports': ^7.16.7
   '@babel/types': ^7.18.4
   '@rollup/plugin-node-resolve': 13.3.0
   '@rollup/plugin-typescript': ^8.3.3
   '@types/babel__core': ^7.1.19
+  '@types/babel__generator': ^7.6.4
+  '@types/node': ^18.7.23
+  prettier: ^2.7.1
   rollup: ^2.75.7
   solid-js: ^1.4.4
+  tslib: ^2.4.0
   typescript: ^4.7.4
   vitest: ^0.16.0
 
 dependencies:
-  '@babel/generator': 7.18.7
   '@babel/helper-module-imports': 7.18.6
   '@babel/types': 7.18.7
 
 devDependencies:
   '@babel/core': 7.18.6
+  '@babel/generator': 7.18.7
   '@rollup/plugin-node-resolve': 13.3.0_rollup@2.75.7
-  '@rollup/plugin-typescript': 8.3.3_okefoyb4o5sittgqayreuhurei
+  '@rollup/plugin-typescript': 8.3.3_g4qkabtmybowem44p7ts7jnbqm
   '@types/babel__core': 7.1.19
+  '@types/babel__generator': 7.6.4
+  '@types/node': 18.7.23
+  prettier: 2.7.1
   rollup: 2.75.7
   solid-js: 1.4.5
+  tslib: 2.4.0
   typescript: 4.7.4
   vitest: 0.16.0
 
@@ -80,6 +88,7 @@ packages:
       '@babel/types': 7.18.7
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
+    dev: true
 
   /@babel/helper-compilation-targets/7.18.6_@babel+core@7.18.6:
     resolution: {integrity: sha512-vFjbfhNCzqdeAtZflUFrG5YIFqGTqsctrtkZ1D/NB0mDW9TwW3GmmUepYY4G9wCET5rY5ugz4OGTcLd614IzQg==}
@@ -236,23 +245,28 @@ packages:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.14
       '@jridgewell/trace-mapping': 0.3.14
+    dev: true
 
   /@jridgewell/resolve-uri/3.0.8:
     resolution: {integrity: sha512-YK5G9LaddzGbcucK4c8h5tWFmMPBvRZ/uyWmN1/SbBdIvqGUdWGkJ5BAaccgs6XbzVLsqbPJrBSFwKv3kT9i7w==}
     engines: {node: '>=6.0.0'}
+    dev: true
 
   /@jridgewell/set-array/1.1.2:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
     engines: {node: '>=6.0.0'}
+    dev: true
 
   /@jridgewell/sourcemap-codec/1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
+    dev: true
 
   /@jridgewell/trace-mapping/0.3.14:
     resolution: {integrity: sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==}
     dependencies:
       '@jridgewell/resolve-uri': 3.0.8
       '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
 
   /@rollup/plugin-node-resolve/13.3.0_rollup@2.75.7:
     resolution: {integrity: sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==}
@@ -269,7 +283,7 @@ packages:
       rollup: 2.75.7
     dev: true
 
-  /@rollup/plugin-typescript/8.3.3_okefoyb4o5sittgqayreuhurei:
+  /@rollup/plugin-typescript/8.3.3_g4qkabtmybowem44p7ts7jnbqm:
     resolution: {integrity: sha512-55L9SyiYu3r/JtqdjhwcwaECXP7JeJ9h1Sg1VWRJKIutla2MdZQodTgcCNybXLMCnqpNLEhS2vGENww98L1npg==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
@@ -283,6 +297,7 @@ packages:
       '@rollup/pluginutils': 3.1.0_rollup@2.75.7
       resolve: 1.22.1
       rollup: 2.75.7
+      tslib: 2.4.0
       typescript: 4.7.4
     dev: true
 
@@ -341,14 +356,14 @@ packages:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
     dev: true
 
-  /@types/node/18.0.0:
-    resolution: {integrity: sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==}
+  /@types/node/18.7.23:
+    resolution: {integrity: sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==}
     dev: true
 
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 18.0.0
+      '@types/node': 18.7.23
     dev: true
 
   /ansi-styles/3.2.1:
@@ -737,6 +752,7 @@ packages:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
 
   /json5/2.2.1:
     resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
@@ -793,6 +809,12 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: true
+
+  /prettier/2.7.1:
+    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
     dev: true
 
   /resolve/1.22.1:
@@ -855,6 +877,10 @@ packages:
   /to-fast-properties/2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
+
+  /tslib/2.4.0:
+    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+    dev: true
 
   /type-detect/4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
@@ -923,7 +949,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.1
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.0.0
+      '@types/node': 18.7.23
       chai: 4.3.6
       debug: 4.3.4
       local-pkg: 0.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,12 +18,12 @@ specifiers:
   vitest: ^0.16.0
 
 dependencies:
+  '@babel/generator': 7.18.7
   '@babel/helper-module-imports': 7.18.6
   '@babel/types': 7.18.7
 
 devDependencies:
   '@babel/core': 7.18.6
-  '@babel/generator': 7.18.7
   '@rollup/plugin-node-resolve': 13.3.0_rollup@2.75.7
   '@rollup/plugin-typescript': 8.3.3_g4qkabtmybowem44p7ts7jnbqm
   '@types/babel__core': 7.1.19
@@ -88,7 +88,6 @@ packages:
       '@babel/types': 7.18.7
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
-    dev: true
 
   /@babel/helper-compilation-targets/7.18.6_@babel+core@7.18.6:
     resolution: {integrity: sha512-vFjbfhNCzqdeAtZflUFrG5YIFqGTqsctrtkZ1D/NB0mDW9TwW3GmmUepYY4G9wCET5rY5ugz4OGTcLd614IzQg==}
@@ -245,28 +244,23 @@ packages:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.14
       '@jridgewell/trace-mapping': 0.3.14
-    dev: true
 
   /@jridgewell/resolve-uri/3.0.8:
     resolution: {integrity: sha512-YK5G9LaddzGbcucK4c8h5tWFmMPBvRZ/uyWmN1/SbBdIvqGUdWGkJ5BAaccgs6XbzVLsqbPJrBSFwKv3kT9i7w==}
     engines: {node: '>=6.0.0'}
-    dev: true
 
   /@jridgewell/set-array/1.1.2:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
     engines: {node: '>=6.0.0'}
-    dev: true
 
   /@jridgewell/sourcemap-codec/1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
-    dev: true
 
   /@jridgewell/trace-mapping/0.3.14:
     resolution: {integrity: sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==}
     dependencies:
       '@jridgewell/resolve-uri': 3.0.8
       '@jridgewell/sourcemap-codec': 1.4.14
-    dev: true
 
   /@rollup/plugin-node-resolve/13.3.0_rollup@2.75.7:
     resolution: {integrity: sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==}
@@ -752,7 +746,6 @@ packages:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /json5/2.2.1:
     resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}

--- a/src/babel-helper-module-imports.d.ts
+++ b/src/babel-helper-module-imports.d.ts
@@ -1,15 +1,15 @@
-declare module '@babel/helper-module-imports' {
-  import { NodePath } from '@babel/traverse';
-  import * as t from '@babel/types';
+declare module "@babel/helper-module-imports" {
+  import { NodePath } from "@babel/traverse";
+  import * as t from "@babel/types";
 
   interface ImportOptions {
     importedSource: string | null;
-    importedType: 'es6' | 'commonjs';
-    importedInterop: 'babel' | 'node' | 'compiled' | 'uncompiled';
-    importingInterop: 'babel' | 'node';
+    importedType: "es6" | "commonjs";
+    importedInterop: "babel" | "node" | "compiled" | "uncompiled";
+    importingInterop: "babel" | "node";
     ensureLiveReference: boolean;
     ensureNoContext: boolean;
-    importPosition: 'before' | 'after';
+    importPosition: "before" | "after";
     nameHint: string;
     blockHoist: number;
   }

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -1,13 +1,13 @@
-import * as babel from '@babel/core';
-import * as t from '@babel/types';
-import generator from '@babel/generator';
-import { addNamed } from '@babel/helper-module-imports';
-import crypto from 'crypto';
+import * as babel from "@babel/core";
+import * as t from "@babel/types";
+import generator from "@babel/generator";
+import { addNamed } from "@babel/helper-module-imports";
+import crypto from "crypto";
 
-type ImportHook = Map<string, t.Identifier>
+type ImportHook = Map<string, t.Identifier>;
 
 interface Options {
-  bundler?: 'esm' | 'standard' | 'vite' | 'webpack5';
+  bundler?: "esm" | "standard" | "vite" | "webpack5";
   fixRender?: boolean;
 }
 
@@ -23,16 +23,11 @@ interface State extends babel.PluginPass {
 }
 
 function isComponentishName(name: string) {
-  return typeof name === 'string' && name[0] >= 'A' && name[0] <= 'Z';
+  return typeof name === "string" && name[0] >= "A" && name[0] <= "Z";
 }
 
-function getModuleIdentifier(
-  hooks: ImportHook,
-  path: babel.NodePath,
-  name: string,
-  mod: string,
-) {
-  const target = `${mod}[${name}]`
+function getModuleIdentifier(hooks: ImportHook, path: babel.NodePath, name: string, mod: string) {
+  const target = `${mod}[${name}]`;
   const current = hooks.get(target);
   if (current) {
     return current;
@@ -45,31 +40,31 @@ function getModuleIdentifier(
 function getSolidRefreshIdentifier(
   hooks: ImportHook,
   path: babel.NodePath,
-  name: string,
+  name: string
 ): t.Identifier {
-  return getModuleIdentifier(hooks, path, name, 'solid-refresh');
+  return getModuleIdentifier(hooks, path, name, "solid-refresh");
 }
 
-function isESMHMR(bundler: Options['bundler']) {
+function isESMHMR(bundler: Options["bundler"]) {
   // The currently known ESM HMR implementations
   // esm - the original ESM HMR Spec
   // vite - Vite's implementation
-  return bundler === 'esm' || bundler === 'vite';
+  return bundler === "esm" || bundler === "vite";
 }
 
-function getHotIdentifier(bundler: Options['bundler']): t.MemberExpression {
+function getHotIdentifier(bundler: Options["bundler"]): t.MemberExpression {
   // vite/esm uses `import.meta.hot`
   if (isESMHMR(bundler)) {
     return t.memberExpression(
-      t.memberExpression(t.identifier('import'), t.identifier('meta')),
-      t.identifier('hot'),
+      t.memberExpression(t.identifier("import"), t.identifier("meta")),
+      t.identifier("hot")
     );
   }
   // webpack 5 uses `import.meta.webpackHot`
-  if (bundler === 'webpack5') {
+  if (bundler === "webpack5") {
     return t.memberExpression(
-      t.memberExpression(t.identifier('import'), t.identifier('meta')),
-      t.identifier('webpackHot'),
+      t.memberExpression(t.identifier("import"), t.identifier("meta")),
+      t.identifier("webpackHot")
     );
   }
   // `module.hot` is the default.
@@ -86,11 +81,7 @@ function getStatementPath(path: babel.NodePath): babel.NodePath | null {
   return null;
 }
 
-function createHotMap(
-  hooks: ImportHook,
-  path: babel.NodePath,
-  name: string,
-): t.Identifier {
+function createHotMap(hooks: ImportHook, path: babel.NodePath, name: string): t.Identifier {
   const current = hooks.get(name);
   if (current) {
     return current;
@@ -98,14 +89,8 @@ function createHotMap(
   const newID = t.identifier(name);
   path.insertBefore(
     t.exportNamedDeclaration(
-      t.variableDeclaration(
-        'const',
-        [t.variableDeclarator(
-          newID,
-          t.objectExpression([]),
-        )],
-      ),
-    ),
+      t.variableDeclaration("const", [t.variableDeclarator(newID, t.objectExpression([]))])
+    )
   );
   hooks.set(name, newID);
   return newID;
@@ -113,14 +98,11 @@ function createHotMap(
 
 function createSignatureValue(node: t.Node): string {
   const code = generator(node);
-  const result = crypto.createHash('sha256').update(code.code).digest('base64');
+  const result = crypto.createHash("sha256").update(code.code).digest("base64");
   return result;
 }
 
-function isForeignBinding(
-  source: babel.NodePath,
-  current: babel.NodePath,
-  name: string): boolean {
+function isForeignBinding(source: babel.NodePath, current: babel.NodePath, name: string): boolean {
   if (source === current) {
     return true;
   }
@@ -133,60 +115,33 @@ function isForeignBinding(
   return true;
 }
 
-function createHotSignature(
-  component: t.Identifier,
-  sign?: t.Expression,
-  deps?: t.Identifier[],
-) {
+function createHotSignature(component: t.Identifier, sign?: t.Expression, deps?: t.Identifier[]) {
   if (sign && deps) {
     return t.objectExpression([
-      t.objectProperty(
-        t.identifier('component'),
-        component,
-      ),
-      t.objectProperty(
-        t.identifier('id'),
-        t.stringLiteral(component.name),
-      ),
-      t.objectProperty(
-        t.identifier('signature'),
-        sign,
-      ),
-      t.objectProperty(
-        t.identifier('dependencies'),
-        t.arrayExpression(deps),
-      ),
+      t.objectProperty(t.identifier("component"), component),
+      t.objectProperty(t.identifier("id"), t.stringLiteral(component.name)),
+      t.objectProperty(t.identifier("signature"), sign),
+      t.objectProperty(t.identifier("dependencies"), t.arrayExpression(deps))
     ]);
   }
   return t.objectExpression([
-    t.objectProperty(
-      t.identifier('component'),
-      component,
-    ),
-    t.objectProperty(
-      t.identifier('id'),
-      t.stringLiteral(component.name),
-    ),
+    t.objectProperty(t.identifier("component"), component),
+    t.objectProperty(t.identifier("id"), t.stringLiteral(component.name))
   ]);
 }
 
-function getBindings(
-  path: babel.NodePath,
-): t.Identifier[] {
+function getBindings(path: babel.NodePath): t.Identifier[] {
   const identifiers = new Set<string>();
   path.traverse({
     Expression(p) {
       if (
-        t.isIdentifier(p.node)
-        && !t.isTypeScript(p.parentPath.node)
-        && isForeignBinding(path, p, p.node.name)
+        t.isIdentifier(p.node) &&
+        !t.isTypeScript(p.parentPath.node) &&
+        isForeignBinding(path, p, p.node.name)
       ) {
         identifiers.add(p.node.name);
       }
-      if (
-        t.isJSXElement(p.node)
-        && t.isJSXMemberExpression(p.node.openingElement.name)
-      ) {
+      if (t.isJSXElement(p.node) && t.isJSXMemberExpression(p.node.openingElement.name)) {
         let base: t.JSXMemberExpression | t.JSXIdentifier = p.node.openingElement.name;
         while (t.isJSXMemberExpression(base)) {
           base = base.object;
@@ -197,20 +152,16 @@ function getBindings(
       }
     }
   });
-  return [...identifiers].map((value) => t.identifier(value));
+  return [...identifiers].map(value => t.identifier(value));
 }
 
 function createStandardHot(
   path: babel.NodePath,
   state: State,
   HotComponent: t.Identifier,
-  rename: t.VariableDeclaration,
+  rename: t.VariableDeclaration
 ) {
-  const HotImport = getSolidRefreshIdentifier(
-    state.hooks,
-    path,
-    'standard',
-  );
+  const HotImport = getSolidRefreshIdentifier(state.hooks, path, "standard");
   const pathToHot = getHotIdentifier(state.opts.bundler);
   const statementPath = getStatementPath(path);
   if (statementPath) {
@@ -220,9 +171,9 @@ function createStandardHot(
     createHotSignature(
       HotComponent,
       state.granular.value ? t.stringLiteral(createSignatureValue(rename)) : undefined,
-      state.granular.value ? getBindings(path) : undefined,
+      state.granular.value ? getBindings(path) : undefined
     ),
-    pathToHot,
+    pathToHot
   ]);
 }
 
@@ -230,83 +181,71 @@ function createESMHot(
   path: babel.NodePath,
   state: State,
   HotComponent: t.Identifier,
-  rename: t.VariableDeclaration,
+  rename: t.VariableDeclaration
 ) {
-  const HotImport = getSolidRefreshIdentifier(
-    state.hooks,
-    path,
-    'esm',
-  );
+  const HotImport = getSolidRefreshIdentifier(state.hooks, path, "esm");
   const pathToHot = getHotIdentifier(state.opts.bundler);
   const handlerId = path.scope.generateUidIdentifier("handler");
   const componentId = path.scope.generateUidIdentifier("Component");
   const statementPath = getStatementPath(path);
   if (statementPath) {
-    const registrationMap = createHotMap(state.hooks, statementPath, '$$registrations');
+    const registrationMap = createHotMap(state.hooks, statementPath, "$$registrations");
     statementPath.insertBefore(rename);
 
     statementPath.insertBefore(
       t.expressionStatement(
         t.assignmentExpression(
-          '=',
-          t.memberExpression(
-            registrationMap,
-            HotComponent,
-          ),
+          "=",
+          t.memberExpression(registrationMap, HotComponent),
           createHotSignature(
             HotComponent,
-            state.granular.value
-              ? t.stringLiteral(createSignatureValue(rename))
-              : undefined,
-              state.granular.value
-              ? getBindings(path)
-              : undefined,
-          ),
-        ),
+            state.granular.value ? t.stringLiteral(createSignatureValue(rename)) : undefined,
+            state.granular.value ? getBindings(path) : undefined
+          )
+        )
       )
     );
     statementPath.insertBefore(
       t.variableDeclaration("const", [
         t.variableDeclarator(
           t.objectPattern([
-            t.objectProperty(t.identifier('handler'), handlerId, false, true),
-            t.objectProperty(t.identifier('Component'), componentId, false, true)
+            t.objectProperty(t.identifier("handler"), handlerId, false, true),
+            t.objectProperty(t.identifier("Component"), componentId, false, true)
           ]),
           t.callExpression(HotImport, [
-            t.memberExpression(
-              registrationMap,
-              HotComponent,
-            ),
-            t.unaryExpression("!", t.unaryExpression("!", pathToHot)),
-          ]),
+            t.memberExpression(registrationMap, HotComponent),
+            t.unaryExpression("!", t.unaryExpression("!", pathToHot))
+          ])
         )
       ])
     );
-    const mod = path.scope.generateUidIdentifier('mod');
-    statementPath.insertBefore(t.ifStatement(
-      pathToHot,
-      t.expressionStatement(
-        t.callExpression(t.memberExpression(pathToHot, t.identifier("accept")), [
-          t.arrowFunctionExpression(
-            [mod],
-            t.blockStatement([
-              t.expressionStatement(
-                t.logicalExpression(
-                  '&&',
-                  t.callExpression(handlerId, [
-                    // Vite interprets this differently
-                    state.opts.bundler === 'esm'
-                      ? t.memberExpression(mod, t.identifier('module'))
-                      : mod
-                  ]),
-                  t.callExpression(t.memberExpression(pathToHot, t.identifier("invalidate")), []),
-                ),
-              ),
-            ]),
-          )
-        ]),
-      ),
-    ));
+    const mod = path.scope.generateUidIdentifier("mod");
+    statementPath.insertBefore(
+      t.ifStatement(
+        pathToHot,
+        t.expressionStatement(
+          t.callExpression(t.memberExpression(pathToHot, t.identifier("accept")), [
+            t.arrowFunctionExpression(
+              [mod],
+              t.blockStatement([
+                t.expressionStatement(
+                  t.logicalExpression(
+                    "&&",
+                    t.callExpression(handlerId, [
+                      // Vite interprets this differently
+                      state.opts.bundler === "esm"
+                        ? t.memberExpression(mod, t.identifier("module"))
+                        : mod
+                    ]),
+                    t.callExpression(t.memberExpression(pathToHot, t.identifier("invalidate")), [])
+                  )
+                )
+              ])
+            )
+          ])
+        )
+      )
+    );
   }
   return componentId;
 }
@@ -315,35 +254,28 @@ function createHot(
   path: babel.NodePath,
   state: State,
   name: t.Identifier | undefined,
-  expression: t.Expression,
+  expression: t.Expression
 ) {
   const HotComponent = name
     ? path.scope.generateUidIdentifier(`Hot$$${name.name}`)
-    : path.scope.generateUidIdentifier('HotComponent');
-  const rename = t.variableDeclaration("const", [
-    t.variableDeclarator(
-      HotComponent,
-      expression,
-    ),
-  ]);
+    : path.scope.generateUidIdentifier("HotComponent");
+  const rename = t.variableDeclaration("const", [t.variableDeclarator(HotComponent, expression)]);
   if (isESMHMR(state.opts.bundler)) {
     return createESMHot(path, state, HotComponent, rename);
   }
   return createStandardHot(path, state, HotComponent, rename);
 }
 
-const SOURCE_MODULE = 'solid-js/web';
+const SOURCE_MODULE = "solid-js/web";
 
 function isValidSpecifier(specifier: t.ImportSpecifier, keyword: string): boolean {
   return (
-    (t.isIdentifier(specifier.imported) && specifier.imported.name === keyword)
-    || (t.isStringLiteral(specifier.imported) && specifier.imported.value === keyword)
+    (t.isIdentifier(specifier.imported) && specifier.imported.name === keyword) ||
+    (t.isStringLiteral(specifier.imported) && specifier.imported.value === keyword)
   );
 }
 
-function captureValidIdentifiers(
-  path: babel.NodePath,
-): Set<t.Identifier> {
+function captureValidIdentifiers(path: babel.NodePath): Set<t.Identifier> {
   const validIdentifiers = new Set<t.Identifier>();
 
   path.traverse({
@@ -352,11 +284,8 @@ function captureValidIdentifiers(
         for (let i = 0, len = p.node.specifiers.length; i < len; i += 1) {
           const specifier = p.node.specifiers[i];
           if (
-            t.isImportSpecifier(specifier)
-            && (
-              isValidSpecifier(specifier, 'render')
-              || isValidSpecifier(specifier, 'hydrate')
-            )
+            t.isImportSpecifier(specifier) &&
+            (isValidSpecifier(specifier, "render") || isValidSpecifier(specifier, "hydrate"))
           ) {
             validIdentifiers.add(specifier.local);
           }
@@ -368,9 +297,7 @@ function captureValidIdentifiers(
   return validIdentifiers;
 }
 
-function captureValidNamespaces(
-  path: babel.NodePath,
-): Set<t.Identifier> {
+function captureValidNamespaces(path: babel.NodePath): Set<t.Identifier> {
   const validNamespaces = new Set<t.Identifier>();
 
   path.traverse({
@@ -393,7 +320,7 @@ function isValidCallee(
   path: babel.NodePath,
   { callee }: t.CallExpression,
   validIdentifiers: Set<t.Identifier>,
-  validNamespaces: Set<t.Identifier>,
+  validNamespaces: Set<t.Identifier>
 ) {
   if (t.isIdentifier(callee)) {
     const binding = path.scope.getBinding(callee.name);
@@ -401,25 +328,23 @@ function isValidCallee(
   }
 
   if (
-    t.isMemberExpression(callee)
-    && !callee.computed
-    && t.isIdentifier(callee.object)
-    && t.isIdentifier(callee.property)
+    t.isMemberExpression(callee) &&
+    !callee.computed &&
+    t.isIdentifier(callee.object) &&
+    t.isIdentifier(callee.property)
   ) {
     const binding = path.scope.getBinding(callee.object.name);
     return (
-      binding
-      && validNamespaces.has(binding.identifier)
-      && (callee.property.name === 'render' || callee.property.name === 'hydrate')
+      binding &&
+      validNamespaces.has(binding.identifier) &&
+      (callee.property.name === "render" || callee.property.name === "hydrate")
     );
   }
 
   return false;
 }
 
-function checkValidRenderCall(
-  path: babel.NodePath,
-): boolean {
+function checkValidRenderCall(path: babel.NodePath): boolean {
   let currentPath = path.parentPath;
 
   while (currentPath) {
@@ -435,120 +360,96 @@ function checkValidRenderCall(
   return false;
 }
 
-function fixRenderCalls(
-  path: babel.NodePath<t.Program>,
-  opts: Options,
-) {
+function fixRenderCalls(path: babel.NodePath<t.Program>, opts: Options) {
   const validIdentifiers = captureValidIdentifiers(path);
   const validNamespaces = captureValidNamespaces(path);
 
   path.traverse({
     ExpressionStatement(p) {
       if (
-        t.isCallExpression(p.node.expression)
-        && checkValidRenderCall(p)
-        && isValidCallee(p, p.node.expression, validIdentifiers, validNamespaces)
+        t.isCallExpression(p.node.expression) &&
+        checkValidRenderCall(p) &&
+        isValidCallee(p, p.node.expression, validIdentifiers, validNamespaces)
       ) {
         // Replace with variable declaration
         const id = p.scope.generateUidIdentifier("cleanup");
         p.replaceWith(
-          t.variableDeclaration(
-            'const',
-            [
-              t.variableDeclarator(
-                id,
-                p.node.expression,
-              ),
-            ],
-          ),
+          t.variableDeclaration("const", [t.variableDeclarator(id, p.node.expression)])
         );
         const pathToHot = getHotIdentifier(opts.bundler);
         p.insertAfter(
           t.ifStatement(
             pathToHot,
             t.expressionStatement(
-              t.callExpression(
-                t.memberExpression(pathToHot, t.identifier('dispose')),
-                [id],
-              ),
-            ),
-          ),
+              t.callExpression(t.memberExpression(pathToHot, t.identifier("dispose")), [id])
+            )
+          )
         );
         p.skip();
       }
-    },
+    }
   });
 }
 
-function getHMRDecline(
-  opts: Options,
-  pathToHot: t.Expression,
-) {
+function getHMRDecline(opts: Options, pathToHot: t.Expression) {
   if (isESMHMR(opts.bundler)) {
-    return (
-      t.ifStatement(
-        pathToHot,
-        t.expressionStatement(
-          t.callExpression(t.memberExpression(pathToHot, t.identifier("decline")), [])
-        )
-      )
-    );
-  }
-  if (opts.bundler === 'webpack5') {
-    return (
-      t.ifStatement(
-        pathToHot,
-        t.expressionStatement(
-          t.callExpression(t.memberExpression(pathToHot, t.identifier("decline")), []),
-        ),
-      )
-    );
-  }
-  
-  return (
-    t.ifStatement(
+    return t.ifStatement(
       pathToHot,
       t.expressionStatement(
-        t.conditionalExpression(
-          t.memberExpression(pathToHot, t.identifier("decline")),
-          t.callExpression(t.memberExpression(pathToHot, t.identifier("decline")), []),
-          t.callExpression(
-            t.memberExpression(
-              t.memberExpression(t.identifier("window"), t.identifier("location")),
-              t.identifier("reload"),
-            ),
-            [],
+        t.callExpression(t.memberExpression(pathToHot, t.identifier("decline")), [])
+      )
+    );
+  }
+  if (opts.bundler === "webpack5") {
+    return t.ifStatement(
+      pathToHot,
+      t.expressionStatement(
+        t.callExpression(t.memberExpression(pathToHot, t.identifier("decline")), [])
+      )
+    );
+  }
+
+  return t.ifStatement(
+    pathToHot,
+    t.expressionStatement(
+      t.conditionalExpression(
+        t.memberExpression(pathToHot, t.identifier("decline")),
+        t.callExpression(t.memberExpression(pathToHot, t.identifier("decline")), []),
+        t.callExpression(
+          t.memberExpression(
+            t.memberExpression(t.identifier("window"), t.identifier("location")),
+            t.identifier("reload")
           ),
+          []
         )
       )
     )
   );
 }
 
-function createDevWarning(
-  path: babel.NodePath<t.Program>,
-  hooks: ImportHook,
-  opts: Options,
-) {
-  path.pushContainer('body', t.ifStatement(
-    t.callExpression(
-      getModuleIdentifier(hooks, path, 'shouldWarnAndDecline', 'solid-refresh'),
-      [],
-    ),
-    getHMRDecline(opts, getHotIdentifier(opts.bundler)),
-  ));
+function createDevWarning(path: babel.NodePath<t.Program>, hooks: ImportHook, opts: Options) {
+  path.pushContainer(
+    "body",
+    t.ifStatement(
+      t.callExpression(
+        getModuleIdentifier(hooks, path, "shouldWarnAndDecline", "solid-refresh"),
+        []
+      ),
+      getHMRDecline(opts, getHotIdentifier(opts.bundler))
+    )
+  );
 }
 
 export default function solidRefreshPlugin(): babel.PluginObj<State> {
   return {
-    name: 'Solid Refresh',
+    name: "Solid Refresh",
     pre() {
       this.hooks = new Map();
       this.processed = {
-        value: false,
+        value: false
       };
       this.granular = {
-        value: false,
+        value: false
       };
     },
     visitor: {
@@ -572,10 +473,7 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
               processed.value = true;
               shouldReload = true;
               const pathToHot = getHotIdentifier(opts.bundler);
-              path.pushContainer(
-                'body',
-                getHMRDecline(opts, pathToHot),
-              );
+              path.pushContainer("body", getHMRDecline(opts, pathToHot));
               break;
             }
           }
@@ -595,33 +493,26 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
         const decl = path.node.declaration;
         // Check if declaration is FunctionDeclaration
         if (
-          t.isFunctionDeclaration(decl)
-          && !(decl.generator || decl.async)
+          t.isFunctionDeclaration(decl) &&
+          !(decl.generator || decl.async) &&
           // Might be component-like, but the only valid components
           // have zero or one parameter
-          && decl.params.length < 2
+          decl.params.length < 2
         ) {
-          // Check if the declaration has an identifier, and then check 
+          // Check if the declaration has an identifier, and then check
           // if the name is component-ish
           if (decl.id && isComponentishName(decl.id.name)) {
-            path.node.declaration = t.variableDeclaration(
-              'const',
-              [
-                t.variableDeclarator(
+            path.node.declaration = t.variableDeclaration("const", [
+              t.variableDeclarator(
+                decl.id,
+                createHot(
+                  path,
+                  state,
                   decl.id,
-                  createHot(
-                    path,
-                    state,
-                    decl.id,
-                    t.functionExpression(
-                      decl.id,
-                      decl.params,
-                      decl.body,
-                    )
-                  ),
+                  t.functionExpression(decl.id, decl.params, decl.body)
                 )
-              ],
-            );
+              )
+            ]);
           }
         }
       },
@@ -632,32 +523,22 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
         const grandParentNode = path.parentPath?.parentPath?.node;
         // Check if the parent of the VariableDeclaration
         // is either a Program or an ExportNamedDeclaration
-        if (
-          t.isProgram(grandParentNode)
-          || t.isExportNamedDeclaration(grandParentNode)
-        ) {
+        if (t.isProgram(grandParentNode) || t.isExportNamedDeclaration(grandParentNode)) {
           const identifier = path.node.id;
           const init = path.node.init;
 
           if (
-            t.isIdentifier(identifier)
-            && isComponentishName(identifier.name)
-            && (
-              // Check for valid FunctionExpression
-              (t.isFunctionExpression(init) && !(init.async || init.generator))
+            t.isIdentifier(identifier) &&
+            isComponentishName(identifier.name) &&
+            // Check for valid FunctionExpression
+            ((t.isFunctionExpression(init) && !(init.async || init.generator)) ||
               // Check for valid ArrowFunctionExpression
-              || (t.isArrowFunctionExpression(init) && !(init.async || init.generator))
-            )
+              (t.isArrowFunctionExpression(init) && !(init.async || init.generator))) &&
             // Might be component-like, but the only valid components
             // have zero or one parameter
-            && init.params.length < 2
+            init.params.length < 2
           ) {
-            path.node.init = createHot(
-              path,
-              state,
-              identifier,
-              init,
-            );
+            path.node.init = createHot(path, state, identifier, init);
           }
         }
       },
@@ -665,67 +546,52 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
         if (state.processed.value) {
           return;
         }
-        if (!(
-          t.isProgram(path.parentPath.node)
-          || t.isExportDefaultDeclaration(path.parentPath.node)
-        )) {
+        if (
+          !(t.isProgram(path.parentPath.node) || t.isExportDefaultDeclaration(path.parentPath.node))
+        ) {
           return;
         }
         const decl = path.node;
         // Check if declaration is FunctionDeclaration
         if (
-          !(decl.generator || decl.async)
+          !(decl.generator || decl.async) &&
           // Might be component-like, but the only valid components
           // have zero or one parameter
-          && decl.params.length < 2
+          decl.params.length < 2
         ) {
-          // Check if the declaration has an identifier, and then check 
+          // Check if the declaration has an identifier, and then check
           // if the name is component-ish
           if (decl.id && isComponentishName(decl.id.name)) {
             const replacement = createHot(
               path,
               state,
               decl.id,
-              t.functionExpression(
-                decl.id,
-                decl.params,
-                decl.body,
-              )
+              t.functionExpression(decl.id, decl.params, decl.body)
             );
             if (t.isExportDefaultDeclaration(path.parentPath.node)) {
               path.replaceWith(replacement);
             } else {
-              path.replaceWith(t.variableDeclaration(
-                'var',
-                [
-                  t.variableDeclarator(
-                    decl.id,
-                    replacement,
-                  ),
-                ]
-              ));
+              path.replaceWith(
+                t.variableDeclaration("var", [t.variableDeclarator(decl.id, replacement)])
+              );
             }
           } else if (
-            !decl.id
-            && decl.params.length === 1
-            && t.isIdentifier(decl.params[0])
-            && decl.params[0].name === 'props'
-            && t.isExportDefaultDeclaration(path.parentPath.node)
+            !decl.id &&
+            decl.params.length === 1 &&
+            t.isIdentifier(decl.params[0]) &&
+            decl.params[0].name === "props" &&
+            t.isExportDefaultDeclaration(path.parentPath.node)
           ) {
             const replacement = createHot(
               path,
               state,
               undefined,
-              t.functionExpression(
-                null,
-                decl.params,
-                decl.body,
-              )
+              t.functionExpression(null, decl.params, decl.body)
             );
             path.replaceWith(replacement);
           }
         }
       }
-    },
-  }
+    }
+  };
 }

--- a/src/create-proxy.ts
+++ b/src/create-proxy.ts
@@ -1,32 +1,35 @@
-import { JSX, createMemo, untrack, $DEVCOMP } from 'solid-js';
+import { JSX, createMemo, untrack, $DEVCOMP } from "solid-js";
 
 interface BaseComponent<P> {
   (props: P): JSX.Element;
 }
 
 export default function createProxy<C extends BaseComponent<P>, P>(
-  source: () => C,
+  source: () => C
 ): (props: P) => JSX.Element {
-  return new Proxy(function hmrCompWrapper(props: P, ...rest) {
-    const s = source();
-    if (!s || $DEVCOMP in s) {
-      return createMemo(() => {
-        const c = source();
-        if (c) {
-          return untrack(() => c(props));
-        }
-        return undefined;
-      });
+  return new Proxy(
+    function hmrCompWrapper(this: any, props: P, ...rest) {
+      const s = source();
+      if (!s || $DEVCOMP in s) {
+        return createMemo(() => {
+          const c = source();
+          if (c) {
+            return untrack(() => c(props));
+          }
+          return undefined;
+        });
+      }
+      // no $DEVCOMP means it did not go through devComponent so source() is a regular function, not a component
+      return s.call(this, props, ...rest);
+    },
+    {
+      get(_, property) {
+        return source()[property as keyof C];
+      },
+      set(_, property, value) {
+        source()[property as keyof C] = value;
+        return true;
+      }
     }
-    // no $DEVCOMP means it did not go through devComponent so source() is a regular function, not a component
-    return s.call(this, props, ...rest);
-  }, {
-    get(_, property: keyof C) {
-      return source()[property];
-    },
-    set(_, property: keyof C, value) {
-      source()[property] = value;
-      return true;
-    },
-  });
+  );
 }

--- a/src/esm.ts
+++ b/src/esm.ts
@@ -22,7 +22,7 @@ interface HotModule<P> {
 
 export default function hot<P>(
   { component: Comp, id, signature, dependencies }: HotSignature<P>,
-  isHot: boolean,
+  isHot: boolean
 ) {
   let Component: (props: P) => JSX.Element = Comp;
   function handler(newModule: HotModule<P>) {
@@ -39,8 +39,8 @@ export default function hot<P>(
     if (registration.signature && registration.dependencies) {
       // Compare old signature and dependencies
       if (
-        registration.signature !== Comp.signature
-        || isListUpdated(registration.dependencies, Comp.dependencies)
+        registration.signature !== Comp.signature ||
+        isListUpdated(registration.dependencies, Comp.dependencies)
       ) {
         // Remount
         Comp.dependencies = registration.dependencies;
@@ -57,7 +57,7 @@ export default function hot<P>(
     return false;
   }
   if (isHot) {
-    const [comp, setComp] = createSignal(Comp);
+    const [comp, setComp] = createSignal(Comp, { internal: true });
     Comp.setComp = setComp;
     Comp.dependencies = dependencies;
     Comp.signature = signature;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,9 @@ export function shouldWarnAndDecline(): boolean {
   }
 
   if (!warned) {
-    console.warn('To use solid-refresh, you need to use the dev build of SolidJS. Make sure your build system supports package.json conditional exports and has the \'development\' condition turned on.');
+    console.warn(
+      "To use solid-refresh, you need to use the dev build of SolidJS. Make sure your build system supports package.json conditional exports and has the 'development' condition turned on."
+    );
     warned = true;
   }
   return true;

--- a/src/standard.ts
+++ b/src/standard.ts
@@ -17,7 +17,7 @@ interface StandardHot {
 }
 
 interface HotSignature<P> {
-  component: (props: P) => JSX.Element
+  component: (props: P) => JSX.Element;
   id: string;
   signature?: string;
   dependencies?: any[];
@@ -25,7 +25,7 @@ interface HotSignature<P> {
 
 export default function hot<P>(
   { component: Comp, id, signature, dependencies }: HotSignature<P>,
-  hot: StandardHot,
+  hot: StandardHot
 ) {
   if (hot) {
     const [comp, setComp] = createSignal(Comp);
@@ -38,8 +38,8 @@ export default function hot<P>(
         // Check if signature changed
         // or dependencies changed
         if (
-          prev[id].signature !== signature
-          || isListUpdated(prev[id].dependencies, dependencies)
+          prev[id].signature !== signature ||
+          isListUpdated(prev[id].dependencies, dependencies)
         ) {
           // Remount
           prev[id].dependencies = dependencies;
@@ -51,11 +51,13 @@ export default function hot<P>(
       }
     }
     hot.dispose(data => {
-      data[id] = prev ? prev[id] : {
-        setComp,
-        signature,
-        dependencies,
-      };
+      data[id] = prev
+        ? prev[id]
+        : {
+            setComp,
+            signature,
+            dependencies
+          };
     });
     hot.accept();
     return createProxy<typeof Comp, P>(comp);

--- a/src/standard.ts
+++ b/src/standard.ts
@@ -28,7 +28,7 @@ export default function hot<P>(
   hot: StandardHot
 ) {
   if (hot) {
-    const [comp, setComp] = createSignal(Comp);
+    const [comp, setComp] = createSignal(Comp, { internal: true });
     const prev = hot.data;
     // Check if there's previous data
     if (prev && prev[id]) {

--- a/tests/esm.test.ts
+++ b/tests/esm.test.ts
@@ -1,364 +1,451 @@
-import * as babel from '@babel/core';
-import { describe, it, expect } from 'vitest';
-import plugin from '../src/babel';
+import * as babel from "@babel/core";
+import { describe, it, expect } from "vitest";
+import plugin from "../src/babel";
 
 async function transform(code: string) {
   const result = await babel.transformAsync(code, {
-    plugins: [
-      [plugin, { bundler: 'esm' }],
-    ],
+    plugins: [[plugin, { bundler: "esm" }]],
     parserOpts: {
-      plugins: [
-        'jsx',
-        'typescript',
-      ],
-    },
+      plugins: ["jsx", "typescript"]
+    }
   });
 
   if (result && result.code) {
     return result.code;
   }
-  throw new Error('Missing code');
+  throw new Error("Missing code");
 }
 
-describe('esm', () => {
-  describe('FunctionDeclaration', () => {
-    it('should transform FunctionDeclaration with valid Component name and params', async () => {
-      expect(await transform(`
+describe("esm", () => {
+  describe("FunctionDeclaration", () => {
+    it("should transform FunctionDeclaration with valid Component name and params", async () => {
+      expect(
+        await transform(`
       function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       function Foo(props) {
       return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip FunctionDeclaration with valid Component name and >1 params', async () => {
-      expect(await transform(`
+    it("should skip FunctionDeclaration with valid Component name and >1 params", async () => {
+      expect(
+        await transform(`
       function Foo(a, b) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip FunctionDeclaration with invalid Component name', async () => {
-      expect(await transform(`
+    it("should skip FunctionDeclaration with invalid Component name", async () => {
+      expect(
+        await transform(`
       function foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip FunctionDeclaration with @refresh skip', async () => {
-      expect(await transform(`
+    it("should skip FunctionDeclaration with @refresh skip", async () => {
+      expect(
+        await transform(`
       // @refresh skip
       function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip FunctionDeclaration with @refresh reload', async () => {
-      expect(await transform(`
+    it("should skip FunctionDeclaration with @refresh reload", async () => {
+      expect(
+        await transform(`
       // @refresh reload
       function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should transform FunctionDeclaration with @refresh granular', async () => {
-      expect(await transform(`
+    it("should transform FunctionDeclaration with @refresh granular", async () => {
+      expect(
+        await transform(`
       // @refresh granular
       function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const example = 'Foo';
       function Foo() {
         return <h1>{example}</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const Example = createContext();
       function Foo() {
         return <Example.Provider>Foo</Example.Provider>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
   });
-  describe('VariableDeclarator', () => {
-    describe('FunctionExpression', () => {
-      it('should transform VariableDeclarator w/ FunctionExpression with valid Component name and params', async () => {
-        expect(await transform(`
+  describe("VariableDeclarator", () => {
+    describe("FunctionExpression", () => {
+      it("should transform VariableDeclarator w/ FunctionExpression with valid Component name and params", async () => {
+        expect(
+          await transform(`
         const Foo = function () {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         const Foo = function (props) {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params", async () => {
+        expect(
+          await transform(`
         const Foo = function (a, b) {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ FunctionExpression with invalid Component name', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ FunctionExpression with invalid Component name", async () => {
+        expect(
+          await transform(`
         const foo = function () {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ FunctionExpression with @refresh skip', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ FunctionExpression with @refresh skip", async () => {
+        expect(
+          await transform(`
         // @refresh skip
         const Foo = function() {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ FunctionExpression with @refresh reload', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ FunctionExpression with @refresh reload", async () => {
+        expect(
+          await transform(`
         // @refresh reload
         const Foo = function() {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should transform VariableDeclarator w/ FunctionExpression with @refresh granular', async () => {
-        expect(await transform(`
+      it("should transform VariableDeclarator w/ FunctionExpression with @refresh granular", async () => {
+        expect(
+          await transform(`
         // @refresh granular
         const Foo = function() {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         // @refresh granular
         const example = 'Foo';
         const Foo = function() {
           return <h1>{example}</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         // @refresh granular
         const Example = createContext();
         const Foo = function() {
           return <Example.Provider>Foo</Example.Provider>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
     });
-    describe('ArrowFunctionExpression', () => {
-      it('should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params', async () => {
-        expect(await transform(`
+    describe("ArrowFunctionExpression", () => {
+      it("should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params", async () => {
+        expect(
+          await transform(`
         const Foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         const Foo = (props) => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params", async () => {
+        expect(
+          await transform(`
         const Foo = (a, b) => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name", async () => {
+        expect(
+          await transform(`
         const foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh skip', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh skip", async () => {
+        expect(
+          await transform(`
         // @refresh skip
         const Foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload", async () => {
+        expect(
+          await transform(`
         // @refresh reload
         const Foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should transform VariableDeclarator w/ ArrowFunctionExpression with @refresh granular', async () => {
-        expect(await transform(`
+      it("should transform VariableDeclarator w/ ArrowFunctionExpression with @refresh granular", async () => {
+        expect(
+          await transform(`
         // @refresh granular
         const Foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         // @refresh granular
         const example = 'Foo';
         const Foo = () => {
           return <h1>{example}</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         // @refresh granular
         const Example = createContext();
         const Foo = () => {
           return <Example.Provider>Foo</Example.Provider>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
     });
   });
-  describe('ExportNamedDeclaration w/ FunctionExpression', () => {
-    it('should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params', async () => {
-      expect(await transform(`
+  describe("ExportNamedDeclaration w/ FunctionExpression", () => {
+    it("should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params", async () => {
+      expect(
+        await transform(`
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       export function Foo(props) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params', async () => {
-      expect(await transform(`
+    it("should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params", async () => {
+      expect(
+        await transform(`
       export function Foo(a, b) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name', async () => {
-      expect(await transform(`
+    it("should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name", async () => {
+      expect(
+        await transform(`
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportNamedDeclaration w/ FunctionExpression with @refresh skip', async () => {
-      expect(await transform(`
+    it("should skip ExportNamedDeclaration w/ FunctionExpression with @refresh skip", async () => {
+      expect(
+        await transform(`
       // @refresh skip
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload', async () => {
-      expect(await transform(`
+    it("should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload", async () => {
+      expect(
+        await transform(`
       // @refresh reload
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should transform ExportNamedDeclaration w/ FunctionExpression with @refresh granular', async () => {
-      expect(await transform(`
+    it("should transform ExportNamedDeclaration w/ FunctionExpression with @refresh granular", async () => {
+      expect(
+        await transform(`
       // @refresh granular
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const example = 'Foo';
       export function Foo() {
         return <h1>{example}</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const Example = createContext();
       export function Foo() {
         return <Example.Provider>Foo</Example.Provider>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
   });
-  describe('ExportDefaultDeclaration w/ FunctionExpression', () => {
-    it('should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params', async () => {
-      expect(await transform(`
+  describe("ExportDefaultDeclaration w/ FunctionExpression", () => {
+    it("should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params", async () => {
+      expect(
+        await transform(`
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       export default function Foo(props) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should transform ExportDefaultDeclaration w/ FunctionExpression with anonymous name and props params', async () => {
-      expect(await transform(`
+    it("should transform ExportDefaultDeclaration w/ FunctionExpression with anonymous name and props params", async () => {
+      expect(
+        await transform(`
       export default function (props) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params', async () => {
-      expect(await transform(`
+    it("should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params", async () => {
+      expect(
+        await transform(`
       export default function Foo(a, b) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name', async () => {
-      expect(await transform(`
+    it("should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name", async () => {
+      expect(
+        await transform(`
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh skip', async () => {
-      expect(await transform(`
+    it("should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh skip", async () => {
+      expect(
+        await transform(`
       // @refresh skip
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload', async () => {
-      expect(await transform(`
+    it("should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload", async () => {
+      expect(
+        await transform(`
       // @refresh reload
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should transform ExportDefaultDeclaration w/ FunctionExpression with @refresh granular', async () => {
-      expect(await transform(`
+    it("should transform ExportDefaultDeclaration w/ FunctionExpression with @refresh granular", async () => {
+      expect(
+        await transform(`
       // @refresh granular
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const example = 'Foo';
       export default function Foo() {
         return <h1>{example}</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const Example = createContext();
       export default function Foo() {
         return <Example.Provider>Foo</Example.Provider>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
   });
 });

--- a/tests/fix-render.test.ts
+++ b/tests/fix-render.test.ts
@@ -1,66 +1,71 @@
-import * as babel from '@babel/core';
-import { describe, it, expect } from 'vitest';
-import plugin from '../src/babel';
+import * as babel from "@babel/core";
+import { describe, it, expect } from "vitest";
+import plugin from "../src/babel";
 
 async function transform(code: string) {
   const result = await babel.transformAsync(code, {
-    plugins: [
-      [plugin, { bundler: 'vite' }],
-    ],
+    plugins: [[plugin, { bundler: "vite" }]],
     parserOpts: {
-      plugins: [
-        'jsx',
-        'typescript',
-      ],
-    },
+      plugins: ["jsx", "typescript"]
+    }
   });
 
   if (result && result.code) {
     return result.code;
   }
-  throw new Error('Missing code');
+  throw new Error("Missing code");
 }
 
-describe('fix render', () => {
-  describe('import specifiers', () => {
-    it('should work with ImportSpecifier + Identifier', async () => {
-      expect(await transform(`
+describe("fix render", () => {
+  describe("import specifiers", () => {
+    it("should work with ImportSpecifier + Identifier", async () => {
+      expect(
+        await transform(`
         import { render } from 'solid-js/web';
   
         render(() => <App />, root);
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should work with ImportSpecifier + aliased Identifier', async () => {
-      expect(await transform(`
+    it("should work with ImportSpecifier + aliased Identifier", async () => {
+      expect(
+        await transform(`
         import { render as Render } from 'solid-js/web';
   
         Render(() => <App />, root);
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should work with ImportSpecifier + aliased Identifier from StringLiteral', async () => {
-      expect(await transform(`
+    it("should work with ImportSpecifier + aliased Identifier from StringLiteral", async () => {
+      expect(
+        await transform(`
         import { 'render' as Render } from 'solid-js/web';
   
         Render(() => <App />, root);
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should work with ImportNamespaceSpecifier', async () => {
-      expect(await transform(`
+    it("should work with ImportNamespaceSpecifier", async () => {
+      expect(
+        await transform(`
         import * as solidWeb from 'solid-js/web';
   
         solidWeb.render(() => <App />, root);
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
   });
-  describe('top-level statements', async () => {
-    it('should work with IfStatement', async () => {
-      expect(await transform(`
+  describe("top-level statements", async () => {
+    it("should work with IfStatement", async () => {
+      expect(
+        await transform(`
         import { render } from 'solid-js/web';
 
         if (root) {
           render(() => <App />, root);
         }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
   });
 });

--- a/tests/standard.test.ts
+++ b/tests/standard.test.ts
@@ -1,364 +1,451 @@
-import * as babel from '@babel/core';
-import { describe, it, expect } from 'vitest';
-import plugin from '../src/babel';
+import * as babel from "@babel/core";
+import { describe, it, expect } from "vitest";
+import plugin from "../src/babel";
 
 async function transform(code: string) {
   const result = await babel.transformAsync(code, {
-    plugins: [
-      [plugin, { bundler: 'standard' }],
-    ],
+    plugins: [[plugin, { bundler: "standard" }]],
     parserOpts: {
-      plugins: [
-        'jsx',
-        'typescript',
-      ],
-    },
+      plugins: ["jsx", "typescript"]
+    }
   });
 
   if (result && result.code) {
     return result.code;
   }
-  throw new Error('Missing code');
+  throw new Error("Missing code");
 }
 
-describe('vite', () => {
-  describe('FunctionDeclaration', () => {
-    it('should transform FunctionDeclaration with valid Component name and params', async () => {
-      expect(await transform(`
+describe("vite", () => {
+  describe("FunctionDeclaration", () => {
+    it("should transform FunctionDeclaration with valid Component name and params", async () => {
+      expect(
+        await transform(`
       function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       function Foo(props) {
       return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip FunctionDeclaration with valid Component name and >1 params', async () => {
-      expect(await transform(`
+    it("should skip FunctionDeclaration with valid Component name and >1 params", async () => {
+      expect(
+        await transform(`
       function Foo(a, b) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip FunctionDeclaration with invalid Component name', async () => {
-      expect(await transform(`
+    it("should skip FunctionDeclaration with invalid Component name", async () => {
+      expect(
+        await transform(`
       function foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip FunctionDeclaration with @refresh skip', async () => {
-      expect(await transform(`
+    it("should skip FunctionDeclaration with @refresh skip", async () => {
+      expect(
+        await transform(`
       // @refresh skip
       function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip FunctionDeclaration with @refresh reload', async () => {
-      expect(await transform(`
+    it("should skip FunctionDeclaration with @refresh reload", async () => {
+      expect(
+        await transform(`
       // @refresh reload
       function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should transform FunctionDeclaration with @refresh granular', async () => {
-      expect(await transform(`
+    it("should transform FunctionDeclaration with @refresh granular", async () => {
+      expect(
+        await transform(`
       // @refresh granular
       function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const example = 'Foo';
       function Foo() {
         return <h1>{example}</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const Example = createContext();
       function Foo() {
         return <Example.Provider>Foo</Example.Provider>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
   });
-  describe('VariableDeclarator', () => {
-    describe('FunctionExpression', () => {
-      it('should transform VariableDeclarator w/ FunctionExpression with valid Component name and params', async () => {
-        expect(await transform(`
+  describe("VariableDeclarator", () => {
+    describe("FunctionExpression", () => {
+      it("should transform VariableDeclarator w/ FunctionExpression with valid Component name and params", async () => {
+        expect(
+          await transform(`
         const Foo = function () {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         const Foo = function (props) {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params", async () => {
+        expect(
+          await transform(`
         const Foo = function (a, b) {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ FunctionExpression with invalid Component name', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ FunctionExpression with invalid Component name", async () => {
+        expect(
+          await transform(`
         const foo = function () {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ FunctionExpression with @refresh skip', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ FunctionExpression with @refresh skip", async () => {
+        expect(
+          await transform(`
         // @refresh skip
         const Foo = function() {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ FunctionExpression with @refresh reload', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ FunctionExpression with @refresh reload", async () => {
+        expect(
+          await transform(`
         // @refresh reload
         const Foo = function() {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should transform VariableDeclarator w/ FunctionExpression with @refresh granular', async () => {
-        expect(await transform(`
+      it("should transform VariableDeclarator w/ FunctionExpression with @refresh granular", async () => {
+        expect(
+          await transform(`
         // @refresh granular
         const Foo = function() {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         // @refresh granular
         const example = 'Foo';
         const Foo = function() {
           return <h1>{example}</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         // @refresh granular
         const Example = createContext();
         const Foo = function() {
           return <Example.Provider>Foo</Example.Provider>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
     });
-    describe('ArrowFunctionExpression', () => {
-      it('should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params', async () => {
-        expect(await transform(`
+    describe("ArrowFunctionExpression", () => {
+      it("should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params", async () => {
+        expect(
+          await transform(`
         const Foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         const Foo = (props) => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params", async () => {
+        expect(
+          await transform(`
         const Foo = (a, b) => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name", async () => {
+        expect(
+          await transform(`
         const foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh skip', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh skip", async () => {
+        expect(
+          await transform(`
         // @refresh skip
         const Foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload", async () => {
+        expect(
+          await transform(`
         // @refresh reload
         const Foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should transform VariableDeclarator w/ ArrowFunctionExpression with @refresh granular', async () => {
-        expect(await transform(`
+      it("should transform VariableDeclarator w/ ArrowFunctionExpression with @refresh granular", async () => {
+        expect(
+          await transform(`
         // @refresh granular
         const Foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         // @refresh granular
         const example = 'Foo';
         const Foo = () => {
           return <h1>{example}</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         // @refresh granular
         const Example = createContext();
         const Foo = () => {
           return <Example.Provider>Foo</Example.Provider>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
     });
   });
-  describe('ExportNamedDeclaration w/ FunctionExpression', () => {
-    it('should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params', async () => {
-      expect(await transform(`
+  describe("ExportNamedDeclaration w/ FunctionExpression", () => {
+    it("should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params", async () => {
+      expect(
+        await transform(`
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       export function Foo(props) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params', async () => {
-      expect(await transform(`
+    it("should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params", async () => {
+      expect(
+        await transform(`
       export function Foo(a, b) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name', async () => {
-      expect(await transform(`
+    it("should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name", async () => {
+      expect(
+        await transform(`
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportNamedDeclaration w/ FunctionExpression with @refresh skip', async () => {
-      expect(await transform(`
+    it("should skip ExportNamedDeclaration w/ FunctionExpression with @refresh skip", async () => {
+      expect(
+        await transform(`
       // @refresh skip
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload', async () => {
-      expect(await transform(`
+    it("should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload", async () => {
+      expect(
+        await transform(`
       // @refresh reload
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should transform ExportNamedDeclaration w/ FunctionExpression with @refresh granular', async () => {
-      expect(await transform(`
+    it("should transform ExportNamedDeclaration w/ FunctionExpression with @refresh granular", async () => {
+      expect(
+        await transform(`
       // @refresh granular
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const example = 'Foo';
       export function Foo() {
         return <h1>{example}</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const Example = createContext();
       export function Foo() {
         return <Example.Provider>Foo</Example.Provider>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
   });
-  describe('ExportDefaultDeclaration w/ FunctionExpression', () => {
-    it('should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params', async () => {
-      expect(await transform(`
+  describe("ExportDefaultDeclaration w/ FunctionExpression", () => {
+    it("should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params", async () => {
+      expect(
+        await transform(`
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       export default function Foo(props) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should transform ExportDefaultDeclaration w/ FunctionExpression with anonymous name and props params', async () => {
-      expect(await transform(`
+    it("should transform ExportDefaultDeclaration w/ FunctionExpression with anonymous name and props params", async () => {
+      expect(
+        await transform(`
       export default function (props) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params', async () => {
-      expect(await transform(`
+    it("should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params", async () => {
+      expect(
+        await transform(`
       export default function Foo(a, b) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name', async () => {
-      expect(await transform(`
+    it("should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name", async () => {
+      expect(
+        await transform(`
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh skip', async () => {
-      expect(await transform(`
+    it("should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh skip", async () => {
+      expect(
+        await transform(`
       // @refresh skip
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload', async () => {
-      expect(await transform(`
+    it("should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload", async () => {
+      expect(
+        await transform(`
       // @refresh reload
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should transform ExportDefaultDeclaration w/ FunctionExpression with @refresh granular', async () => {
-      expect(await transform(`
+    it("should transform ExportDefaultDeclaration w/ FunctionExpression with @refresh granular", async () => {
+      expect(
+        await transform(`
       // @refresh granular
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const example = 'Foo';
       export default function Foo() {
         return <h1>{example}</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const Example = createContext();
       export default function Foo() {
         return <Example.Provider>Foo</Example.Provider>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
   });
 });

--- a/tests/vite.test.ts
+++ b/tests/vite.test.ts
@@ -1,364 +1,451 @@
-import * as babel from '@babel/core';
-import { describe, it, expect } from 'vitest';
-import plugin from '../src/babel';
+import * as babel from "@babel/core";
+import { describe, it, expect } from "vitest";
+import plugin from "../src/babel";
 
 async function transform(code: string) {
   const result = await babel.transformAsync(code, {
-    plugins: [
-      [plugin, { bundler: 'vite' }],
-    ],
+    plugins: [[plugin, { bundler: "vite" }]],
     parserOpts: {
-      plugins: [
-        'jsx',
-        'typescript',
-      ],
-    },
+      plugins: ["jsx", "typescript"]
+    }
   });
 
   if (result && result.code) {
     return result.code;
   }
-  throw new Error('Missing code');
+  throw new Error("Missing code");
 }
 
-describe('vite', () => {
-  describe('FunctionDeclaration', () => {
-    it('should transform FunctionDeclaration with valid Component name and params', async () => {
-      expect(await transform(`
+describe("vite", () => {
+  describe("FunctionDeclaration", () => {
+    it("should transform FunctionDeclaration with valid Component name and params", async () => {
+      expect(
+        await transform(`
       function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       function Foo(props) {
       return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip FunctionDeclaration with valid Component name and >1 params', async () => {
-      expect(await transform(`
+    it("should skip FunctionDeclaration with valid Component name and >1 params", async () => {
+      expect(
+        await transform(`
       function Foo(a, b) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip FunctionDeclaration with invalid Component name', async () => {
-      expect(await transform(`
+    it("should skip FunctionDeclaration with invalid Component name", async () => {
+      expect(
+        await transform(`
       function foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip FunctionDeclaration with @refresh skip', async () => {
-      expect(await transform(`
+    it("should skip FunctionDeclaration with @refresh skip", async () => {
+      expect(
+        await transform(`
       // @refresh skip
       function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip FunctionDeclaration with @refresh reload', async () => {
-      expect(await transform(`
+    it("should skip FunctionDeclaration with @refresh reload", async () => {
+      expect(
+        await transform(`
       // @refresh reload
       function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should transform FunctionDeclaration with @refresh granular', async () => {
-      expect(await transform(`
+    it("should transform FunctionDeclaration with @refresh granular", async () => {
+      expect(
+        await transform(`
       // @refresh granular
       function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const example = 'Foo';
       function Foo() {
         return <h1>{example}</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const Example = createContext();
       function Foo() {
         return <Example.Provider>Foo</Example.Provider>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
   });
-  describe('VariableDeclarator', () => {
-    describe('FunctionExpression', () => {
-      it('should transform VariableDeclarator w/ FunctionExpression with valid Component name and params', async () => {
-        expect(await transform(`
+  describe("VariableDeclarator", () => {
+    describe("FunctionExpression", () => {
+      it("should transform VariableDeclarator w/ FunctionExpression with valid Component name and params", async () => {
+        expect(
+          await transform(`
         const Foo = function () {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         const Foo = function (props) {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params", async () => {
+        expect(
+          await transform(`
         const Foo = function (a, b) {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ FunctionExpression with invalid Component name', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ FunctionExpression with invalid Component name", async () => {
+        expect(
+          await transform(`
         const foo = function () {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ FunctionExpression with @refresh skip', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ FunctionExpression with @refresh skip", async () => {
+        expect(
+          await transform(`
         // @refresh skip
         const Foo = function() {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ FunctionExpression with @refresh reload', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ FunctionExpression with @refresh reload", async () => {
+        expect(
+          await transform(`
         // @refresh reload
         const Foo = function() {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should transform VariableDeclarator w/ FunctionExpression with @refresh granular', async () => {
-        expect(await transform(`
+      it("should transform VariableDeclarator w/ FunctionExpression with @refresh granular", async () => {
+        expect(
+          await transform(`
         // @refresh granular
         const Foo = function() {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         // @refresh granular
         const example = 'Foo';
         const Foo = function() {
           return <h1>{example}</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         // @refresh granular
         const Example = createContext();
         const Foo = function() {
           return <Example.Provider>Foo</Example.Provider>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
     });
-    describe('ArrowFunctionExpression', () => {
-      it('should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params', async () => {
-        expect(await transform(`
+    describe("ArrowFunctionExpression", () => {
+      it("should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params", async () => {
+        expect(
+          await transform(`
         const Foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         const Foo = (props) => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params", async () => {
+        expect(
+          await transform(`
         const Foo = (a, b) => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name", async () => {
+        expect(
+          await transform(`
         const foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh skip', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh skip", async () => {
+        expect(
+          await transform(`
         // @refresh skip
         const Foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload", async () => {
+        expect(
+          await transform(`
         // @refresh reload
         const Foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should transform VariableDeclarator w/ ArrowFunctionExpression with @refresh granular', async () => {
-        expect(await transform(`
+      it("should transform VariableDeclarator w/ ArrowFunctionExpression with @refresh granular", async () => {
+        expect(
+          await transform(`
         // @refresh granular
         const Foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         // @refresh granular
         const example = 'Foo';
         const Foo = () => {
           return <h1>{example}</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         // @refresh granular
         const Example = createContext();
         const Foo = () => {
           return <Example.Provider>Foo</Example.Provider>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
     });
   });
-  describe('ExportNamedDeclaration w/ FunctionExpression', () => {
-    it('should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params', async () => {
-      expect(await transform(`
+  describe("ExportNamedDeclaration w/ FunctionExpression", () => {
+    it("should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params", async () => {
+      expect(
+        await transform(`
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       export function Foo(props) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params', async () => {
-      expect(await transform(`
+    it("should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params", async () => {
+      expect(
+        await transform(`
       export function Foo(a, b) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name', async () => {
-      expect(await transform(`
+    it("should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name", async () => {
+      expect(
+        await transform(`
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportNamedDeclaration w/ FunctionExpression with @refresh skip', async () => {
-      expect(await transform(`
+    it("should skip ExportNamedDeclaration w/ FunctionExpression with @refresh skip", async () => {
+      expect(
+        await transform(`
       // @refresh skip
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload', async () => {
-      expect(await transform(`
+    it("should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload", async () => {
+      expect(
+        await transform(`
       // @refresh reload
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should transform ExportNamedDeclaration w/ FunctionExpression with @refresh granular', async () => {
-      expect(await transform(`
+    it("should transform ExportNamedDeclaration w/ FunctionExpression with @refresh granular", async () => {
+      expect(
+        await transform(`
       // @refresh granular
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const example = 'Foo';
       export function Foo() {
         return <h1>{example}</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const Example = createContext();
       export function Foo() {
         return <Example.Provider>Foo</Example.Provider>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
   });
-  describe('ExportDefaultDeclaration w/ FunctionExpression', () => {
-    it('should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params', async () => {
-      expect(await transform(`
+  describe("ExportDefaultDeclaration w/ FunctionExpression", () => {
+    it("should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params", async () => {
+      expect(
+        await transform(`
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       export default function Foo(props) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should transform ExportDefaultDeclaration w/ FunctionExpression with anonymous name and props params', async () => {
-      expect(await transform(`
+    it("should transform ExportDefaultDeclaration w/ FunctionExpression with anonymous name and props params", async () => {
+      expect(
+        await transform(`
       export default function (props) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params', async () => {
-      expect(await transform(`
+    it("should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params", async () => {
+      expect(
+        await transform(`
       export default function Foo(a, b) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name', async () => {
-      expect(await transform(`
+    it("should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name", async () => {
+      expect(
+        await transform(`
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh skip', async () => {
-      expect(await transform(`
+    it("should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh skip", async () => {
+      expect(
+        await transform(`
       // @refresh skip
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload', async () => {
-      expect(await transform(`
+    it("should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload", async () => {
+      expect(
+        await transform(`
       // @refresh reload
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should transform ExportDefaultDeclaration w/ FunctionExpression with @refresh granular', async () => {
-      expect(await transform(`
+    it("should transform ExportDefaultDeclaration w/ FunctionExpression with @refresh granular", async () => {
+      expect(
+        await transform(`
       // @refresh granular
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const example = 'Foo';
       export default function Foo() {
         return <h1>{example}</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const Example = createContext();
       export default function Foo() {
         return <Example.Provider>Foo</Example.Provider>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
   });
 });

--- a/tests/webpack5.test.ts
+++ b/tests/webpack5.test.ts
@@ -1,364 +1,451 @@
-import * as babel from '@babel/core';
-import { describe, it, expect } from 'vitest';
-import plugin from '../src/babel';
+import * as babel from "@babel/core";
+import { describe, it, expect } from "vitest";
+import plugin from "../src/babel";
 
 async function transform(code: string) {
   const result = await babel.transformAsync(code, {
-    plugins: [
-      [plugin, { bundler: 'webpack5' }],
-    ],
+    plugins: [[plugin, { bundler: "webpack5" }]],
     parserOpts: {
-      plugins: [
-        'jsx',
-        'typescript',
-      ],
-    },
+      plugins: ["jsx", "typescript"]
+    }
   });
 
   if (result && result.code) {
     return result.code;
   }
-  throw new Error('Missing code');
+  throw new Error("Missing code");
 }
 
-describe('webpack5', () => {
-  describe('FunctionDeclaration', () => {
-    it('should transform FunctionDeclaration with valid Component name and params', async () => {
-      expect(await transform(`
+describe("webpack5", () => {
+  describe("FunctionDeclaration", () => {
+    it("should transform FunctionDeclaration with valid Component name and params", async () => {
+      expect(
+        await transform(`
       function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       function Foo(props) {
       return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip FunctionDeclaration with valid Component name and >1 params', async () => {
-      expect(await transform(`
+    it("should skip FunctionDeclaration with valid Component name and >1 params", async () => {
+      expect(
+        await transform(`
       function Foo(a, b) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip FunctionDeclaration with invalid Component name', async () => {
-      expect(await transform(`
+    it("should skip FunctionDeclaration with invalid Component name", async () => {
+      expect(
+        await transform(`
       function foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip FunctionDeclaration with @refresh skip', async () => {
-      expect(await transform(`
+    it("should skip FunctionDeclaration with @refresh skip", async () => {
+      expect(
+        await transform(`
       // @refresh skip
       function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip FunctionDeclaration with @refresh reload', async () => {
-      expect(await transform(`
+    it("should skip FunctionDeclaration with @refresh reload", async () => {
+      expect(
+        await transform(`
       // @refresh reload
       function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should transform FunctionDeclaration with @refresh granular', async () => {
-      expect(await transform(`
+    it("should transform FunctionDeclaration with @refresh granular", async () => {
+      expect(
+        await transform(`
       // @refresh granular
       function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const example = 'Foo';
       function Foo() {
         return <h1>{example}</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const Example = createContext();
       function Foo() {
         return <Example.Provider>Foo</Example.Provider>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
   });
-  describe('VariableDeclarator', () => {
-    describe('FunctionExpression', () => {
-      it('should transform VariableDeclarator w/ FunctionExpression with valid Component name and params', async () => {
-        expect(await transform(`
+  describe("VariableDeclarator", () => {
+    describe("FunctionExpression", () => {
+      it("should transform VariableDeclarator w/ FunctionExpression with valid Component name and params", async () => {
+        expect(
+          await transform(`
         const Foo = function () {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         const Foo = function (props) {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params", async () => {
+        expect(
+          await transform(`
         const Foo = function (a, b) {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ FunctionExpression with invalid Component name', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ FunctionExpression with invalid Component name", async () => {
+        expect(
+          await transform(`
         const foo = function () {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ FunctionExpression with @refresh skip', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ FunctionExpression with @refresh skip", async () => {
+        expect(
+          await transform(`
         // @refresh skip
         const Foo = function() {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ FunctionExpression with @refresh reload', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ FunctionExpression with @refresh reload", async () => {
+        expect(
+          await transform(`
         // @refresh reload
         const Foo = function() {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should transform VariableDeclarator w/ FunctionExpression with @refresh granular', async () => {
-        expect(await transform(`
+      it("should transform VariableDeclarator w/ FunctionExpression with @refresh granular", async () => {
+        expect(
+          await transform(`
         // @refresh granular
         const Foo = function() {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         // @refresh granular
         const example = 'Foo';
         const Foo = function() {
           return <h1>{example}</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         // @refresh granular
         const Example = createContext();
         const Foo = function() {
           return <Example.Provider>Foo</Example.Provider>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
     });
-    describe('ArrowFunctionExpression', () => {
-      it('should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params', async () => {
-        expect(await transform(`
+    describe("ArrowFunctionExpression", () => {
+      it("should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params", async () => {
+        expect(
+          await transform(`
         const Foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         const Foo = (props) => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params", async () => {
+        expect(
+          await transform(`
         const Foo = (a, b) => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name", async () => {
+        expect(
+          await transform(`
         const foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh skip', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh skip", async () => {
+        expect(
+          await transform(`
         // @refresh skip
         const Foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload', async () => {
-        expect(await transform(`
+      it("should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload", async () => {
+        expect(
+          await transform(`
         // @refresh reload
         const Foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
-      it('should transform VariableDeclarator w/ ArrowFunctionExpression with @refresh granular', async () => {
-        expect(await transform(`
+      it("should transform VariableDeclarator w/ ArrowFunctionExpression with @refresh granular", async () => {
+        expect(
+          await transform(`
         // @refresh granular
         const Foo = () => {
           return <h1>Foo</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         // @refresh granular
         const example = 'Foo';
         const Foo = () => {
           return <h1>{example}</h1>;
         }
-        `)).toMatchSnapshot();
-        expect(await transform(`
+        `)
+        ).toMatchSnapshot();
+        expect(
+          await transform(`
         // @refresh granular
         const Example = createContext();
         const Foo = () => {
           return <Example.Provider>Foo</Example.Provider>;
         }
-        `)).toMatchSnapshot();
+        `)
+        ).toMatchSnapshot();
       });
     });
   });
-  describe('ExportNamedDeclaration w/ FunctionExpression', () => {
-    it('should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params', async () => {
-      expect(await transform(`
+  describe("ExportNamedDeclaration w/ FunctionExpression", () => {
+    it("should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params", async () => {
+      expect(
+        await transform(`
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       export function Foo(props) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params', async () => {
-      expect(await transform(`
+    it("should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params", async () => {
+      expect(
+        await transform(`
       export function Foo(a, b) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name', async () => {
-      expect(await transform(`
+    it("should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name", async () => {
+      expect(
+        await transform(`
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportNamedDeclaration w/ FunctionExpression with @refresh skip', async () => {
-      expect(await transform(`
+    it("should skip ExportNamedDeclaration w/ FunctionExpression with @refresh skip", async () => {
+      expect(
+        await transform(`
       // @refresh skip
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload', async () => {
-      expect(await transform(`
+    it("should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload", async () => {
+      expect(
+        await transform(`
       // @refresh reload
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should transform ExportNamedDeclaration w/ FunctionExpression with @refresh granular', async () => {
-      expect(await transform(`
+    it("should transform ExportNamedDeclaration w/ FunctionExpression with @refresh granular", async () => {
+      expect(
+        await transform(`
       // @refresh granular
       export function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const example = 'Foo';
       export function Foo() {
         return <h1>{example}</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const Example = createContext();
       export function Foo() {
         return <Example.Provider>Foo</Example.Provider>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
   });
-  describe('ExportDefaultDeclaration w/ FunctionExpression', () => {
-    it('should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params', async () => {
-      expect(await transform(`
+  describe("ExportDefaultDeclaration w/ FunctionExpression", () => {
+    it("should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params", async () => {
+      expect(
+        await transform(`
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       export default function Foo(props) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should transform ExportDefaultDeclaration w/ FunctionExpression with anonymous name and props params', async () => {
-      expect(await transform(`
+    it("should transform ExportDefaultDeclaration w/ FunctionExpression with anonymous name and props params", async () => {
+      expect(
+        await transform(`
       export default function (props) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params', async () => {
-      expect(await transform(`
+    it("should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params", async () => {
+      expect(
+        await transform(`
       export default function Foo(a, b) {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name', async () => {
-      expect(await transform(`
+    it("should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name", async () => {
+      expect(
+        await transform(`
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh skip', async () => {
-      expect(await transform(`
+    it("should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh skip", async () => {
+      expect(
+        await transform(`
       // @refresh skip
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload', async () => {
-      expect(await transform(`
+    it("should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload", async () => {
+      expect(
+        await transform(`
       // @refresh reload
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
-    it('should transform ExportDefaultDeclaration w/ FunctionExpression with @refresh granular', async () => {
-      expect(await transform(`
+    it("should transform ExportDefaultDeclaration w/ FunctionExpression with @refresh granular", async () => {
+      expect(
+        await transform(`
       // @refresh granular
       export default function Foo() {
         return <h1>Foo</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const example = 'Foo';
       export default function Foo() {
         return <h1>{example}</h1>;
       }
-      `)).toMatchSnapshot();
-      expect(await transform(`
+      `)
+      ).toMatchSnapshot();
+      expect(
+        await transform(`
       // @refresh granular
       const Example = createContext();
       export default function Foo() {
         return <Example.Provider>Foo</Example.Provider>;
       }
-      `)).toMatchSnapshot();
+      `)
+      ).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
- add `format` script, (and `prettier`)
- add missing dev deps, (`@types/babel__generator`, `@types/node`, `tslib`)
- fix types in create-proxy
- adds `{ internal: true }` option to created signals