### PR TITLE
fix: memoize esm component getter/setter in hot.data (#26)

### DIFF
--- a/babel.js
+++ b/babel.js
@@ -163,7 +163,7 @@ function createESMHot(path, state, HotComponent, rename) {
                 t__namespace.objectProperty(t__namespace.identifier("Component"), componentId, false, true)
             ]), t__namespace.callExpression(HotImport, [
                 t__namespace.memberExpression(registrationMap, HotComponent),
-                t__namespace.unaryExpression("!", t__namespace.unaryExpression("!", pathToHot))
+                pathToHot
             ]))
         ]));
         const mod = path.scope.generateUidIdentifier("mod");

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -214,7 +214,7 @@ function createESMHot(
           ]),
           t.callExpression(HotImport, [
             t.memberExpression(registrationMap, HotComponent),
-            t.unaryExpression("!", t.unaryExpression("!", pathToHot))
+            pathToHot
           ])
         )
       ])

--- a/tests/__snapshots__/esm.test.ts.snap
+++ b/tests/__snapshots__/esm.test.ts.snap
@@ -34,7 +34,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -70,7 +70,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -101,7 +101,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -131,7 +131,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -157,7 +157,7 @@ $$registrations._HotComponent = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._HotComponent, !!import.meta.hot);
+} = _esm($$registrations._HotComponent, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -183,7 +183,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -209,7 +209,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -252,7 +252,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -288,7 +288,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -319,7 +319,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -349,7 +349,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -375,7 +375,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -401,7 +401,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -468,7 +468,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -499,7 +499,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -529,7 +529,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -555,7 +555,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -581,7 +581,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -648,7 +648,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -679,7 +679,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -709,7 +709,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -735,7 +735,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -761,7 +761,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -828,7 +828,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -859,7 +859,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -889,7 +889,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -915,7 +915,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();
@@ -941,7 +941,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod.module) && import.meta.hot.invalidate();

--- a/tests/__snapshots__/vite.test.ts.snap
+++ b/tests/__snapshots__/vite.test.ts.snap
@@ -34,7 +34,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -70,7 +70,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -101,7 +101,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -131,7 +131,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -157,7 +157,7 @@ $$registrations._HotComponent = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._HotComponent, !!import.meta.hot);
+} = _esm($$registrations._HotComponent, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -183,7 +183,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -209,7 +209,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -252,7 +252,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -288,7 +288,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -319,7 +319,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -349,7 +349,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -375,7 +375,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -401,7 +401,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -468,7 +468,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -499,7 +499,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -529,7 +529,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -555,7 +555,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -581,7 +581,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -648,7 +648,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -679,7 +679,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -709,7 +709,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -735,7 +735,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -761,7 +761,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -828,7 +828,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -859,7 +859,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -889,7 +889,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -915,7 +915,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();
@@ -941,7 +941,7 @@ $$registrations._Hot$$Foo = {
 const {
   handler: _handler,
   Component: _Component
-} = _esm($$registrations._Hot$$Foo, !!import.meta.hot);
+} = _esm($$registrations._Hot$$Foo, import.meta.hot);
 
 if (import.meta.hot) import.meta.hot.accept(_mod => {
   _handler(_mod) && import.meta.hot.invalidate();


### PR DESCRIPTION
### Background
This uses vite `hot.data` to store and recover previous component getter/setters. Without it, child components are not able to get updated after a change in the parent component, as mentioned in #26.

The goal of this fix was to change as few things as possible in solid-refresh, because as discussed with @lxsmnsyc solid-refresh is getting a proper larger rework soon-ish anyways.

### Reproduction
1. Clone: https://github.com/katywings/solid-hmr-lost-signals
2. Disable the "overrides" section in "package.json"
    - The overrides section already includes my github repository with the fix
3. Follow instructions in https://github.com/katywings/solid-hmr-lost-signals

[Bildschirmaufzeichnung vom 2022-12-22, 13-40-11.webm](https://user-images.githubusercontent.com/4012401/211046716-bb74d245-cd91-4fa5-a0e5-893b09f4f817.webm)

### How did I test the changes
- I ran `pnpm run test`
- I used the "package.json" overrides feature to test this fix in my projects and the reproduction repository
    - Example of the overrides: https://github.com/katywings/solid-hmr-lost-signals/blob/2a1c40a8e32e3d7326c6c5bd27ff4eeeb1734cff/package.json#L23

### Tested vite versions
- 3.1.8
- 3.2.4
- 4.0.0