### PR TITLE
feat: add moduleName option

### DIFF
--- a/src/babel/index.ts
+++ b/src/babel/index.ts
@@ -24,6 +24,7 @@ interface Options {
   bundler?: RuntimeType;
   fixRender?: boolean;
   imports?: ImportIdentity[];
+  moduleName?: string;
 }
 
 type ImportHook = Map<string, t.Identifier>;
@@ -75,7 +76,7 @@ function getSolidRefreshIdentifier(state: State, path: babel.NodePath, name: str
   if (current) {
     return current;
   }
-  const newID = addNamed(path, name, SOLID_REFRESH_MODULE);
+  const newID = addNamed(path, name, state.opts.moduleName || SOLID_REFRESH_MODULE);
   state.hooks.set(target, newID);
   return newID;
 }


### PR DESCRIPTION
Hope to provide a option that can customize the module name. When this option is not passed in, the default is to use 'solid-refresh'.