### PR TITLE
fix: some stuff

### DIFF
--- a/input.js
+++ b/input.js
@@ -1,3 +1,5 @@
+// Hello
+
 function Example(props) {
   return (
     <h1>

--- a/package.json
+++ b/package.json
@@ -51,28 +51,25 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.6",
-    "@biomejs/biome": "^1.5.1",
+    "@babel/core": "^7.23.9",
+    "@biomejs/biome": "^1.5.3",
     "@rollup/plugin-node-resolve": "^15.2.3",
-    "@rollup/plugin-typescript": "^11.1.5",
+    "@rollup/plugin-typescript": "^11.1.6",
     "@types/babel__core": "^7.20.5",
     "@types/babel__generator": "^7.6.8",
-    "@types/babel__helper-module-imports": "^7.18.3",
-    "@types/babel__traverse": "^7.20.4",
-    "@types/node": "^20.10.5",
-    "babel-preset-solid": "^1.8.9",
-    "rollup": "^4.9.1",
-    "solid-js": "^1.8.7",
+    "@types/node": "^20.11.10",
+    "babel-preset-solid": "^1.8.12",
+    "rollup": "^4.9.6",
+    "solid-js": "^1.8.12",
     "tslib": "^2.6.2",
     "typescript": "^5.3.3",
-    "vitest": "^1.1.0"
+    "vitest": "^1.2.2"
   },
   "peerDependencies": {
     "solid-js": "^1.3"
   },
   "dependencies": {
     "@babel/generator": "^7.23.6",
-    "@babel/helper-module-imports": "^7.22.15",
     "@babel/types": "^7.23.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,50 +8,41 @@ dependencies:
   '@babel/generator':
     specifier: ^7.23.6
     version: 7.23.6
-  '@babel/helper-module-imports':
-    specifier: ^7.22.15
-    version: 7.22.15
   '@babel/types':
     specifier: ^7.23.6
     version: 7.23.6
 
 devDependencies:
   '@babel/core':
-    specifier: ^7.23.6
-    version: 7.23.6
+    specifier: ^7.23.9
+    version: 7.23.9
   '@biomejs/biome':
-    specifier: ^1.5.1
-    version: 1.5.1
+    specifier: ^1.5.3
+    version: 1.5.3
   '@rollup/plugin-node-resolve':
     specifier: ^15.2.3
-    version: 15.2.3(rollup@4.9.1)
+    version: 15.2.3(rollup@4.9.6)
   '@rollup/plugin-typescript':
-    specifier: ^11.1.5
-    version: 11.1.5(rollup@4.9.1)(tslib@2.6.2)(typescript@5.3.3)
+    specifier: ^11.1.6
+    version: 11.1.6(rollup@4.9.6)(tslib@2.6.2)(typescript@5.3.3)
   '@types/babel__core':
     specifier: ^7.20.5
     version: 7.20.5
   '@types/babel__generator':
     specifier: ^7.6.8
     version: 7.6.8
-  '@types/babel__helper-module-imports':
-    specifier: ^7.18.3
-    version: 7.18.3
-  '@types/babel__traverse':
-    specifier: ^7.20.4
-    version: 7.20.4
   '@types/node':
-    specifier: ^20.10.5
-    version: 20.10.5
+    specifier: ^20.11.10
+    version: 20.11.10
   babel-preset-solid:
-    specifier: ^1.8.9
-    version: 1.8.9(@babel/core@7.23.6)
+    specifier: ^1.8.12
+    version: 1.8.12(@babel/core@7.23.9)
   rollup:
-    specifier: ^4.9.1
-    version: 4.9.1
+    specifier: ^4.9.6
+    version: 4.9.6
   solid-js:
-    specifier: ^1.8.7
-    version: 1.8.7
+    specifier: ^1.8.12
+    version: 1.8.12
   tslib:
     specifier: ^2.6.2
     version: 2.6.2
@@ -59,8 +50,8 @@ devDependencies:
     specifier: ^5.3.3
     version: 5.3.3
   vitest:
-    specifier: ^1.1.0
-    version: 1.1.0(@types/node@20.10.5)
+    specifier: ^1.2.2
+    version: 1.2.2(@types/node@20.11.10)
 
 packages:
 
@@ -85,20 +76,20 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/core@7.23.6:
-    resolution: {integrity: sha512-FxpRyGjrMJXh7X3wGLGhNDCRiwpWEF74sKjTLDJSG5Kyvow3QZaG0Adbqzi9ZrVjTWpsX+2cxWXD71NMg93kdw==}
+  /@babel/core@7.23.9:
+    resolution: {integrity: sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@babel/code-frame': 7.23.5
       '@babel/generator': 7.23.6
       '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.6)
-      '@babel/helpers': 7.23.6
-      '@babel/parser': 7.23.6
-      '@babel/template': 7.22.15
-      '@babel/traverse': 7.23.6
-      '@babel/types': 7.23.6
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.9)
+      '@babel/helpers': 7.23.9
+      '@babel/parser': 7.23.9
+      '@babel/template': 7.23.9
+      '@babel/traverse': 7.23.9
+      '@babel/types': 7.23.9
       convert-source-map: 2.0.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -137,15 +128,15 @@ packages:
     resolution: {integrity: sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.22.15
-      '@babel/types': 7.23.6
+      '@babel/template': 7.23.9
+      '@babel/types': 7.23.9
     dev: true
 
   /@babel/helper-hoist-variables@7.22.5:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.6
+      '@babel/types': 7.23.9
     dev: true
 
   /@babel/helper-module-imports@7.18.6:
@@ -159,15 +150,16 @@ packages:
     resolution: {integrity: sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.6
+      '@babel/types': 7.23.9
+    dev: true
 
-  /@babel/helper-module-transforms@7.23.3(@babel/core@7.23.6):
+  /@babel/helper-module-transforms@7.23.3(@babel/core@7.23.9):
     resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.23.9
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
@@ -184,14 +176,14 @@ packages:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.6
+      '@babel/types': 7.23.9
     dev: true
 
   /@babel/helper-split-export-declaration@7.22.6:
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.23.6
+      '@babel/types': 7.23.9
     dev: true
 
   /@babel/helper-string-parser@7.23.4:
@@ -207,13 +199,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helpers@7.23.6:
-    resolution: {integrity: sha512-wCfsbN4nBidDRhpDhvcKlzHWCTlgJYUUdSJfzXb2NuBssDSIjc3xcb+znA7l+zYsFljAcGM0aFkN40cR3lXiGA==}
+  /@babel/helpers@7.23.9:
+    resolution: {integrity: sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.22.15
-      '@babel/traverse': 7.23.6
-      '@babel/types': 7.23.6
+      '@babel/template': 7.23.9
+      '@babel/traverse': 7.23.9
+      '@babel/types': 7.23.9
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -235,35 +227,35 @@ packages:
       '@babel/types': 7.23.6
     dev: true
 
-  /@babel/parser@7.23.6:
-    resolution: {integrity: sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==}
+  /@babel/parser@7.23.9:
+    resolution: {integrity: sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.23.6
+      '@babel/types': 7.23.9
     dev: true
 
-  /@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.23.6):
+  /@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.23.9):
     resolution: {integrity: sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/template@7.22.15:
-    resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
+  /@babel/template@7.23.9:
+    resolution: {integrity: sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.23.5
-      '@babel/parser': 7.23.6
-      '@babel/types': 7.23.6
+      '@babel/parser': 7.23.9
+      '@babel/types': 7.23.9
     dev: true
 
-  /@babel/traverse@7.23.6:
-    resolution: {integrity: sha512-czastdK1e8YByZqezMPFiZ8ahwVMh/ESl9vPgvgdB9AmFMGP5jfpFax74AQgl5zj4XHzqeYAg2l8PuUeRS1MgQ==}
+  /@babel/traverse@7.23.9:
+    resolution: {integrity: sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.23.5
@@ -272,8 +264,8 @@ packages:
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.23.6
-      '@babel/types': 7.23.6
+      '@babel/parser': 7.23.9
+      '@babel/types': 7.23.9
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -288,24 +280,33 @@ packages:
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
 
-  /@biomejs/biome@1.5.1:
-    resolution: {integrity: sha512-rdMA/N1Zc1nxUtbXMVr+50Sg/Pezz+9qGQa2uyRWFtrCoyr3dv0pVz+0ifGGue18ip50ZH8x2r5CV7zo8Q/0mA==}
+  /@babel/types@7.23.9:
+    resolution: {integrity: sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.23.4
+      '@babel/helper-validator-identifier': 7.22.20
+      to-fast-properties: 2.0.0
+    dev: true
+
+  /@biomejs/biome@1.5.3:
+    resolution: {integrity: sha512-yvZCa/g3akwTaAQ7PCwPWDCkZs3Qa5ONg/fgOUT9e6wAWsPftCjLQFPXBeGxPK30yZSSpgEmRCfpGTmVbUjGgg==}
     engines: {node: '>=14.*'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.5.1
-      '@biomejs/cli-darwin-x64': 1.5.1
-      '@biomejs/cli-linux-arm64': 1.5.1
-      '@biomejs/cli-linux-arm64-musl': 1.5.1
-      '@biomejs/cli-linux-x64': 1.5.1
-      '@biomejs/cli-linux-x64-musl': 1.5.1
-      '@biomejs/cli-win32-arm64': 1.5.1
-      '@biomejs/cli-win32-x64': 1.5.1
+      '@biomejs/cli-darwin-arm64': 1.5.3
+      '@biomejs/cli-darwin-x64': 1.5.3
+      '@biomejs/cli-linux-arm64': 1.5.3
+      '@biomejs/cli-linux-arm64-musl': 1.5.3
+      '@biomejs/cli-linux-x64': 1.5.3
+      '@biomejs/cli-linux-x64-musl': 1.5.3
+      '@biomejs/cli-win32-arm64': 1.5.3
+      '@biomejs/cli-win32-x64': 1.5.3
     dev: true
 
-  /@biomejs/cli-darwin-arm64@1.5.1:
-    resolution: {integrity: sha512-E9pLakmSVHP6UH2uqAghqEkr/IHAIDfDyCedqJVnyFc+uufNTHwB8id4XTiWy/eKIdgxHZsTSE+R+W0IqrTNVQ==}
+  /@biomejs/cli-darwin-arm64@1.5.3:
+    resolution: {integrity: sha512-ImU7mh1HghEDyqNmxEZBoMPr8SxekkZuYcs+gynKlNW+TALQs7swkERiBLkG9NR0K1B3/2uVzlvYowXrmlW8hw==}
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [darwin]
@@ -313,8 +314,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-darwin-x64@1.5.1:
-    resolution: {integrity: sha512-8O1F+FcoCi02JlocyilB6R3y3kT9sRkBCRwYddaBIScQe2hCme/mA2rVzrhCCHhskrclJ51GEKjkEORj4/8c2A==}
+  /@biomejs/cli-darwin-x64@1.5.3:
+    resolution: {integrity: sha512-vCdASqYnlpq/swErH7FD6nrFz0czFtK4k/iLgj0/+VmZVjineFPgevOb+Sr9vz0tk0GfdQO60bSpI74zU8M9Dw==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [darwin]
@@ -322,8 +323,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-arm64-musl@1.5.1:
-    resolution: {integrity: sha512-Lw9G3LUdhRMp8L8RMeVevnfQCa7luT6ubQ8GRjLju32glxWKefpDrzgfHixGyvTQPlhnYjQ+V8/QQ/I7WPzOoA==}
+  /@biomejs/cli-linux-arm64-musl@1.5.3:
+    resolution: {integrity: sha512-DYuMizUYUBYfS0IHGjDrOP1RGipqWfMGEvNEJ398zdtmCKLXaUvTimiox5dvx4X15mBK5M2m8wgWUgOP1giUpQ==}
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [linux]
@@ -331,8 +332,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-arm64@1.5.1:
-    resolution: {integrity: sha512-25gwY4FMzmi1Rl6N835raLq7nzTk+PyEQd88k9Em6dqtI4qpljqmZlMmVjOiwXKe3Ee80J/Vlh7BM36lsHUTEg==}
+  /@biomejs/cli-linux-arm64@1.5.3:
+    resolution: {integrity: sha512-cupBQv0sNF1OKqBfx7EDWMSsKwRrBUZfjXawT4s6hKV6ALq7p0QzWlxr/sDmbKMLOaLQtw2Qgu/77N9rm+f9Rg==}
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [linux]
@@ -340,8 +341,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-x64-musl@1.5.1:
-    resolution: {integrity: sha512-5gapxc/VlwTgGRbTc9h8PMTpf8eNahIBauFUGSXncHgayi3VpezKSicgaQ1bb8FahVXf/5eNEVxVARq/or71Ag==}
+  /@biomejs/cli-linux-x64-musl@1.5.3:
+    resolution: {integrity: sha512-UUHiAnlDqr2Y/LpvshBFhUYMWkl2/Jn+bi3U6jKuav0qWbbBKU/ByHgR4+NBxpKBYoCtWxhnmatfH1bpPIuZMw==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [linux]
@@ -349,8 +350,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-x64@1.5.1:
-    resolution: {integrity: sha512-YDM0gZP4UbAuaBI3DVbUuj5X+Omm6uxzD1Qpc6hcduH1kzXzs9L0ee7cn/kJtNndoXR8MlmUS0O0/wWvZf2YaA==}
+  /@biomejs/cli-linux-x64@1.5.3:
+    resolution: {integrity: sha512-YQrSArQvcv4FYsk7Q91Yv4uuu5F8hJyORVcv3zsjCLGkjIjx2RhjYLpTL733SNL7v33GmOlZY0eFR1ko38tuUw==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [linux]
@@ -358,8 +359,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-win32-arm64@1.5.1:
-    resolution: {integrity: sha512-TVpLBOLUMLQmH2VRFBKFr3rgEkr7XvG4QZxHOxWB9Ivc/sQPvg4aHMd8qpgPKXABGUnultyc9t0+WvfIDxuALg==}
+  /@biomejs/cli-win32-arm64@1.5.3:
+    resolution: {integrity: sha512-HxatYH7vf/kX9nrD+pDYuV2GI9GV8EFo6cfKkahAecTuZLPxryHx1WEfJthp5eNsE0+09STGkKIKjirP0ufaZA==}
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [win32]
@@ -367,8 +368,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-win32-x64@1.5.1:
-    resolution: {integrity: sha512-qx8EKwScZmVYZjMPZ6GF3ZUmgg/N6zqh+d8vHA2E43opNCyqIPTl89sOqkc7zd1CyyABDWxsbqI9Ih6xTT6hnQ==}
+  /@biomejs/cli-win32-x64@1.5.3:
+    resolution: {integrity: sha512-fMvbSouZEASU7mZH8SIJSANDm5OqsjgtVXlbUqxwed6BP7uuHRSs396Aqwh2+VoW8fwTpp6ybIUoC9FrzB0kyA==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [win32]
@@ -626,7 +627,7 @@ packages:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
 
-  /@rollup/plugin-node-resolve@15.2.3(rollup@4.9.1):
+  /@rollup/plugin-node-resolve@15.2.3(rollup@4.9.6):
     resolution: {integrity: sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -635,17 +636,17 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@4.9.1)
+      '@rollup/pluginutils': 5.0.2(rollup@4.9.6)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.0
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.1
-      rollup: 4.9.1
+      rollup: 4.9.6
     dev: true
 
-  /@rollup/plugin-typescript@11.1.5(rollup@4.9.1)(tslib@2.6.2)(typescript@5.3.3):
-    resolution: {integrity: sha512-rnMHrGBB0IUEv69Q8/JGRD/n4/n6b3nfpufUu26axhUcboUzv/twfZU8fIBbTOphRAe0v8EyxzeDpKXqGHfyDA==}
+  /@rollup/plugin-typescript@11.1.6(rollup@4.9.6)(tslib@2.6.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.14.0||^3.0.0||^4.0.0
@@ -657,14 +658,14 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@4.9.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.9.6)
       resolve: 1.22.1
-      rollup: 4.9.1
+      rollup: 4.9.6
       tslib: 2.6.2
       typescript: 5.3.3
     dev: true
 
-  /@rollup/pluginutils@5.0.2(rollup@4.9.1):
+  /@rollup/pluginutils@5.0.2(rollup@4.9.6):
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -676,107 +677,122 @@ packages:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 4.9.1
+      rollup: 4.9.6
     dev: true
 
-  /@rollup/rollup-android-arm-eabi@4.9.1:
-    resolution: {integrity: sha512-6vMdBZqtq1dVQ4CWdhFwhKZL6E4L1dV6jUjuBvsavvNJSppzi6dLBbuV+3+IyUREaj9ZFvQefnQm28v4OCXlig==}
+  /@rollup/pluginutils@5.1.0(rollup@4.9.6):
+    resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.0
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 4.9.6
+    dev: true
+
+  /@rollup/rollup-android-arm-eabi@4.9.6:
+    resolution: {integrity: sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==}
     cpu: [arm]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-android-arm64@4.9.1:
-    resolution: {integrity: sha512-Jto9Fl3YQ9OLsTDWtLFPtaIMSL2kwGyGoVCmPC8Gxvym9TCZm4Sie+cVeblPO66YZsYH8MhBKDMGZ2NDxuk/XQ==}
+  /@rollup/rollup-android-arm64@4.9.6:
+    resolution: {integrity: sha512-T14aNLpqJ5wzKNf5jEDpv5zgyIqcpn1MlwCrUXLrwoADr2RkWA0vOWP4XxbO9aiO3dvMCQICZdKeDrFl7UMClw==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-arm64@4.9.1:
-    resolution: {integrity: sha512-LtYcLNM+bhsaKAIGwVkh5IOWhaZhjTfNOkGzGqdHvhiCUVuJDalvDxEdSnhFzAn+g23wgsycmZk1vbnaibZwwA==}
+  /@rollup/rollup-darwin-arm64@4.9.6:
+    resolution: {integrity: sha512-CqNNAyhRkTbo8VVZ5R85X73H3R5NX9ONnKbXuHisGWC0qRbTTxnF1U4V9NafzJbgGM0sHZpdO83pLPzq8uOZFw==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-x64@4.9.1:
-    resolution: {integrity: sha512-KyP/byeXu9V+etKO6Lw3E4tW4QdcnzDG/ake031mg42lob5tN+5qfr+lkcT/SGZaH2PdW4Z1NX9GHEkZ8xV7og==}
+  /@rollup/rollup-darwin-x64@4.9.6:
+    resolution: {integrity: sha512-zRDtdJuRvA1dc9Mp6BWYqAsU5oeLixdfUvkTHuiYOHwqYuQ4YgSmi6+/lPvSsqc/I0Omw3DdICx4Tfacdzmhog==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.9.1:
-    resolution: {integrity: sha512-Yqz/Doumf3QTKplwGNrCHe/B2p9xqDghBZSlAY0/hU6ikuDVQuOUIpDP/YcmoT+447tsZTmirmjgG3znvSCR0Q==}
+  /@rollup/rollup-linux-arm-gnueabihf@4.9.6:
+    resolution: {integrity: sha512-oNk8YXDDnNyG4qlNb6is1ojTOGL/tRhbbKeE/YuccItzerEZT68Z9gHrY3ROh7axDc974+zYAPxK5SH0j/G+QQ==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.9.1:
-    resolution: {integrity: sha512-u3XkZVvxcvlAOlQJ3UsD1rFvLWqu4Ef/Ggl40WAVCuogf4S1nJPHh5RTgqYFpCOvuGJ7H5yGHabjFKEZGExk5Q==}
+  /@rollup/rollup-linux-arm64-gnu@4.9.6:
+    resolution: {integrity: sha512-Z3O60yxPtuCYobrtzjo0wlmvDdx2qZfeAWTyfOjEDqd08kthDKexLpV97KfAeUXPosENKd8uyJMRDfFMxcYkDQ==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.9.1:
-    resolution: {integrity: sha512-0XSYN/rfWShW+i+qjZ0phc6vZ7UWI8XWNz4E/l+6edFt+FxoEghrJHjX1EY/kcUGCnZzYYRCl31SNdfOi450Aw==}
+  /@rollup/rollup-linux-arm64-musl@4.9.6:
+    resolution: {integrity: sha512-gpiG0qQJNdYEVad+1iAsGAbgAnZ8j07FapmnIAQgODKcOTjLEWM9sRb+MbQyVsYCnA0Im6M6QIq6ax7liws6eQ==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-riscv64-gnu@4.9.1:
-    resolution: {integrity: sha512-LmYIO65oZVfFt9t6cpYkbC4d5lKHLYv5B4CSHRpnANq0VZUQXGcCPXHzbCXCz4RQnx7jvlYB1ISVNCE/omz5cw==}
+  /@rollup/rollup-linux-riscv64-gnu@4.9.6:
+    resolution: {integrity: sha512-+uCOcvVmFUYvVDr27aiyun9WgZk0tXe7ThuzoUTAukZJOwS5MrGbmSlNOhx1j80GdpqbOty05XqSl5w4dQvcOA==}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.9.1:
-    resolution: {integrity: sha512-kr8rEPQ6ns/Lmr/hiw8sEVj9aa07gh1/tQF2Y5HrNCCEPiCBGnBUt9tVusrcBBiJfIt1yNaXN6r1CCmpbFEDpg==}
+  /@rollup/rollup-linux-x64-gnu@4.9.6:
+    resolution: {integrity: sha512-HUNqM32dGzfBKuaDUBqFB7tP6VMN74eLZ33Q9Y1TBqRDn+qDonkAUyKWwF9BR9unV7QUzffLnz9GrnKvMqC/fw==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-musl@4.9.1:
-    resolution: {integrity: sha512-t4QSR7gN+OEZLG0MiCgPqMWZGwmeHhsM4AkegJ0Kiy6TnJ9vZ8dEIwHw1LcZKhbHxTY32hp9eVCMdR3/I8MGRw==}
+  /@rollup/rollup-linux-x64-musl@4.9.6:
+    resolution: {integrity: sha512-ch7M+9Tr5R4FK40FHQk8VnML0Szi2KRujUgHXd/HjuH9ifH72GUmw6lStZBo3c3GB82vHa0ZoUfjfcM7JiiMrQ==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.9.1:
-    resolution: {integrity: sha512-7XI4ZCBN34cb+BH557FJPmh0kmNz2c25SCQeT9OiFWEgf8+dL6ZwJ8f9RnUIit+j01u07Yvrsuu1rZGxJCc51g==}
+  /@rollup/rollup-win32-arm64-msvc@4.9.6:
+    resolution: {integrity: sha512-VD6qnR99dhmTQ1mJhIzXsRcTBvTjbfbGGwKAHcu+52cVl15AC/kplkhxzW/uT0Xl62Y/meBKDZvoJSJN+vTeGA==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.9.1:
-    resolution: {integrity: sha512-yE5c2j1lSWOH5jp+Q0qNL3Mdhr8WuqCNVjc6BxbVfS5cAS6zRmdiw7ktb8GNpDCEUJphILY6KACoFoRtKoqNQg==}
+  /@rollup/rollup-win32-ia32-msvc@4.9.6:
+    resolution: {integrity: sha512-J9AFDq/xiRI58eR2NIDfyVmTYGyIZmRcvcAoJ48oDld/NTR8wyiPUu2X/v1navJ+N/FGg68LEbX3Ejd6l8B7MQ==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-x64-msvc@4.9.1:
-    resolution: {integrity: sha512-PyJsSsafjmIhVgaI1Zdj7m8BB8mMckFah/xbpplObyHfiXzKcI5UOUXRyOdHW7nz4DpMCuzLnF7v5IWHenCwYA==}
+  /@rollup/rollup-win32-x64-msvc@4.9.6:
+    resolution: {integrity: sha512-jqzNLhNDvIZOrt69Ce4UjGRpXJBzhUBzawMwnaDAwyHriki3XollsewxWzOzz+4yOFDkuJHtTsZFwMxhYJWmLQ==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -803,13 +819,6 @@ packages:
       '@babel/types': 7.23.6
     dev: true
 
-  /@types/babel__helper-module-imports@7.18.3:
-    resolution: {integrity: sha512-2pyr9Vlriessj2KI85SEF7qma8vA3vzquQMw3wn6kL5lsfjH/YxJ1Noytk4/FJElpYybUbyaC37CVfEgfyme9A==}
-    dependencies:
-      '@types/babel__core': 7.20.5
-      '@types/babel__traverse': 7.20.4
-    dev: true
-
   /@types/babel__template@7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
@@ -827,8 +836,12 @@ packages:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
     dev: true
 
-  /@types/node@20.10.5:
-    resolution: {integrity: sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==}
+  /@types/estree@1.0.5:
+    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+    dev: true
+
+  /@types/node@20.11.10:
+    resolution: {integrity: sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==}
     dependencies:
       undici-types: 5.26.5
     dev: true
@@ -837,46 +850,47 @@ packages:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
     dev: true
 
-  /@vitest/expect@1.1.0:
-    resolution: {integrity: sha512-9IE2WWkcJo2BR9eqtY5MIo3TPmS50Pnwpm66A6neb2hvk/QSLfPXBz2qdiwUOQkwyFuuXEUj5380CbwfzW4+/w==}
+  /@vitest/expect@1.2.2:
+    resolution: {integrity: sha512-3jpcdPAD7LwHUUiT2pZTj2U82I2Tcgg2oVPvKxhn6mDI2On6tfvPQTjAI4628GUGDZrCm4Zna9iQHm5cEexOAg==}
     dependencies:
-      '@vitest/spy': 1.1.0
-      '@vitest/utils': 1.1.0
+      '@vitest/spy': 1.2.2
+      '@vitest/utils': 1.2.2
       chai: 4.3.10
     dev: true
 
-  /@vitest/runner@1.1.0:
-    resolution: {integrity: sha512-zdNLJ00pm5z/uhbWF6aeIJCGMSyTyWImy3Fcp9piRGvueERFlQFbUwCpzVce79OLm2UHk9iwaMSOaU9jVHgNVw==}
+  /@vitest/runner@1.2.2:
+    resolution: {integrity: sha512-JctG7QZ4LSDXr5CsUweFgcpEvrcxOV1Gft7uHrvkQ+fsAVylmWQvnaAr/HDp3LAH1fztGMQZugIheTWjaGzYIg==}
     dependencies:
-      '@vitest/utils': 1.1.0
+      '@vitest/utils': 1.2.2
       p-limit: 5.0.0
       pathe: 1.1.1
     dev: true
 
-  /@vitest/snapshot@1.1.0:
-    resolution: {integrity: sha512-5O/wyZg09V5qmNmAlUgCBqflvn2ylgsWJRRuPrnHEfDNT6tQpQ8O1isNGgo+VxofISHqz961SG3iVvt3SPK/QQ==}
+  /@vitest/snapshot@1.2.2:
+    resolution: {integrity: sha512-SmGY4saEw1+bwE1th6S/cZmPxz/Q4JWsl7LvbQIky2tKE35US4gd0Mjzqfr84/4OD0tikGWaWdMja/nWL5NIPA==}
     dependencies:
       magic-string: 0.30.5
       pathe: 1.1.1
       pretty-format: 29.7.0
     dev: true
 
-  /@vitest/spy@1.1.0:
-    resolution: {integrity: sha512-sNOVSU/GE+7+P76qYo+VXdXhXffzWZcYIPQfmkiRxaNCSPiLANvQx5Mx6ZURJ/ndtEkUJEpvKLXqAYTKEY+lTg==}
+  /@vitest/spy@1.2.2:
+    resolution: {integrity: sha512-k9Gcahssw8d7X3pSLq3e3XEu/0L78mUkCjivUqCQeXJm9clfXR/Td8+AP+VC1O6fKPIDLcHDTAmBOINVuv6+7g==}
     dependencies:
       tinyspy: 2.2.0
     dev: true
 
-  /@vitest/utils@1.1.0:
-    resolution: {integrity: sha512-z+s510fKmYz4Y41XhNs3vcuFTFhcij2YF7F8VQfMEYAAUfqQh0Zfg7+w9xdgFGhPf3tX3TicAe+8BDITk6ampQ==}
+  /@vitest/utils@1.2.2:
+    resolution: {integrity: sha512-WKITBHLsBHlpjnDQahr+XK6RE7MiAsgrIkr0pGhQ9ygoxBfUeG0lUG5iLlzqjmKSlBv3+j5EGsriBzh+C3Tq9g==}
     dependencies:
       diff-sequences: 29.6.3
+      estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
     dev: true
 
-  /acorn-walk@8.3.1:
-    resolution: {integrity: sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==}
+  /acorn-walk@8.3.2:
+    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
     engines: {node: '>=0.4.0'}
     dev: true
 
@@ -902,26 +916,26 @@ packages:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
 
-  /babel-plugin-jsx-dom-expressions@0.37.13(@babel/core@7.23.6):
-    resolution: {integrity: sha512-oAEMMIgU0h1DmHn4ZDaBBFc08nsVJciLq9pF7g0ZdpeIDKfY4zXjXr8+/oBjKhXG8nyomhnTodPjeG+/ZXcWXQ==}
+  /babel-plugin-jsx-dom-expressions@0.37.16(@babel/core@7.23.9):
+    resolution: {integrity: sha512-ItMD16axbk+FqVb9vIbc7AOpNowy46VaSUHaMYPn+erPGpMCxsahQ1Iv+qhPMthjxtn5ROVMZ5AJtQvzjxjiNA==}
     peerDependencies:
       '@babel/core': ^7.20.12
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.23.9
       '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.23.6)
+      '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.23.9)
       '@babel/types': 7.23.6
       html-entities: 2.3.3
       validate-html-nesting: 1.2.2
     dev: true
 
-  /babel-preset-solid@1.8.9(@babel/core@7.23.6):
-    resolution: {integrity: sha512-1awR1QCoryXtAdnjsrx/eVBTYz+tpHUDOdBXqG9oVV7S0ojf2MV/woR0+8BG+LMXVzIr60oKYzCZ9UZGafxmpg==}
+  /babel-preset-solid@1.8.12(@babel/core@7.23.9):
+    resolution: {integrity: sha512-Fx1dYokeRwouWqjLkdobA6qvTAPxFSEU2c5PlkfJjlNyONlSMJQPaX0Bae5pc+5/LNteb9BseOp4UHwQu6VC9Q==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.6
-      babel-plugin-jsx-dom-expressions: 0.37.13(@babel/core@7.23.6)
+      '@babel/core': 7.23.9
+      babel-plugin-jsx-dom-expressions: 0.37.16(@babel/core@7.23.9)
     dev: true
 
   /browserslist@4.22.2:
@@ -957,7 +971,7 @@ packages:
       check-error: 1.0.3
       deep-eql: 4.1.3
       get-func-name: 2.0.2
-      loupe: 2.3.6
+      loupe: 2.3.7
       pathval: 1.1.1
       type-detect: 4.0.8
     dev: true
@@ -1082,6 +1096,12 @@ packages:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
     dev: true
 
+  /estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.0
+    dev: true
+
   /execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
@@ -1200,13 +1220,6 @@ packages:
     dependencies:
       mlly: 1.4.2
       pkg-types: 1.0.3
-    dev: true
-
-  /loupe@2.3.6:
-    resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
-    deprecated: Please upgrade to 2.3.7 which fixes GHSA-4q6p-r6v2-jvc5
-    dependencies:
-      get-func-name: 2.0.2
     dev: true
 
   /loupe@2.3.7:
@@ -1351,24 +1364,26 @@ packages:
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
 
-  /rollup@4.9.1:
-    resolution: {integrity: sha512-pgPO9DWzLoW/vIhlSoDByCzcpX92bKEorbgXuZrqxByte3JFk2xSW2JEeAcyLc9Ru9pqcNNW+Ob7ntsk2oT/Xw==}
+  /rollup@4.9.6:
+    resolution: {integrity: sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+    dependencies:
+      '@types/estree': 1.0.5
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.9.1
-      '@rollup/rollup-android-arm64': 4.9.1
-      '@rollup/rollup-darwin-arm64': 4.9.1
-      '@rollup/rollup-darwin-x64': 4.9.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.9.1
-      '@rollup/rollup-linux-arm64-gnu': 4.9.1
-      '@rollup/rollup-linux-arm64-musl': 4.9.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.9.1
-      '@rollup/rollup-linux-x64-gnu': 4.9.1
-      '@rollup/rollup-linux-x64-musl': 4.9.1
-      '@rollup/rollup-win32-arm64-msvc': 4.9.1
-      '@rollup/rollup-win32-ia32-msvc': 4.9.1
-      '@rollup/rollup-win32-x64-msvc': 4.9.1
+      '@rollup/rollup-android-arm-eabi': 4.9.6
+      '@rollup/rollup-android-arm64': 4.9.6
+      '@rollup/rollup-darwin-arm64': 4.9.6
+      '@rollup/rollup-darwin-x64': 4.9.6
+      '@rollup/rollup-linux-arm-gnueabihf': 4.9.6
+      '@rollup/rollup-linux-arm64-gnu': 4.9.6
+      '@rollup/rollup-linux-arm64-musl': 4.9.6
+      '@rollup/rollup-linux-riscv64-gnu': 4.9.6
+      '@rollup/rollup-linux-x64-gnu': 4.9.6
+      '@rollup/rollup-linux-x64-musl': 4.9.6
+      '@rollup/rollup-win32-arm64-msvc': 4.9.6
+      '@rollup/rollup-win32-ia32-msvc': 4.9.6
+      '@rollup/rollup-win32-x64-msvc': 4.9.6
       fsevents: 2.3.3
     dev: true
 
@@ -1377,8 +1392,17 @@ packages:
     hasBin: true
     dev: true
 
-  /seroval@0.15.1:
-    resolution: {integrity: sha512-OPVtf0qmeC7RW+ScVX+7aOS+xoIM7pWcZ0jOWg2aTZigCydgRB04adfteBRbecZnnrO1WuGQ+C3tLeBBzX2zSQ==}
+  /seroval-plugins@1.0.4(seroval@1.0.4):
+    resolution: {integrity: sha512-DQ2IK6oQVvy8k+c2V5x5YCtUa/GGGsUwUBNN9UqohrZ0rWdUapBFpNMYP1bCyRHoxOJjdKGl+dieacFIpU/i1A==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+    dependencies:
+      seroval: 1.0.4
+    dev: true
+
+  /seroval@1.0.4:
+    resolution: {integrity: sha512-qQs/N+KfJu83rmszFQaTxcoJoPn6KNUruX4KmnmyD0oZkUoiNvJ1rpdYKDf4YHM05k+HOgCxa3yvf15QbVijGg==}
     engines: {node: '>=10'}
     dev: true
 
@@ -1403,11 +1427,12 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
-  /solid-js@1.8.7:
-    resolution: {integrity: sha512-9dzrSVieh2zj3SnJ02II6xZkonR6c+j/91b7XZUNcC6xSaldlqjjGh98F1fk5cRJ8ZTkzqF5fPIWDxEOs6QZXA==}
+  /solid-js@1.8.12:
+    resolution: {integrity: sha512-sLE/i6M9FSWlov3a2pTC5ISzanH2aKwqXTZj+bbFt4SUrVb4iGEa7fpILBMOxsQjkv3eXqEk6JVLlogOdTe0UQ==}
     dependencies:
       csstype: 3.1.1
-      seroval: 0.15.1
+      seroval: 1.0.4
+      seroval-plugins: 1.0.4(seroval@1.0.4)
     dev: true
 
   /source-map-js@1.0.2:
@@ -1450,8 +1475,8 @@ packages:
     resolution: {integrity: sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg==}
     dev: true
 
-  /tinypool@0.8.1:
-    resolution: {integrity: sha512-zBTCK0cCgRROxvs9c0CGK838sPkeokNGdQVUUwHAbynHFlmyJYj825f/oRs528HaIJ97lo0pLIlDUzwN+IorWg==}
+  /tinypool@0.8.2:
+    resolution: {integrity: sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -1502,8 +1527,8 @@ packages:
     resolution: {integrity: sha512-hGdgQozCsQJMyfK5urgFcWEqsSSrK63Awe0t/IMR0bZ0QMtnuaiHzThW81guu3qx9abLi99NEuiaN6P9gVYsNg==}
     dev: true
 
-  /vite-node@1.1.0(@types/node@20.10.5):
-    resolution: {integrity: sha512-jV48DDUxGLEBdHCQvxL1mEh7+naVy+nhUUUaPAZLd3FJgXuxQiewHcfeZebbJ6onDqNGkP4r3MhQ342PRlG81Q==}
+  /vite-node@1.2.2(@types/node@20.11.10):
+    resolution: {integrity: sha512-1as4rDTgVWJO3n1uHmUYqq7nsFgINQ9u+mRcXpjeOMJUmviqNKjcZB7UfRZrlM7MjYXMKpuWp5oGkjaFLnjawg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
@@ -1511,7 +1536,7 @@ packages:
       debug: 4.3.4
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 5.0.10(@types/node@20.10.5)
+      vite: 5.0.10(@types/node@20.11.10)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -1523,7 +1548,7 @@ packages:
       - terser
     dev: true
 
-  /vite@5.0.10(@types/node@20.10.5):
+  /vite@5.0.10(@types/node@20.11.10):
     resolution: {integrity: sha512-2P8J7WWgmc355HUMlFrwofacvr98DAjoE52BfdbwQtyLH06XKwaL/FMnmKM2crF0iX4MpmMKoDlNCB1ok7zHCw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -1551,16 +1576,16 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.10.5
+      '@types/node': 20.11.10
       esbuild: 0.19.10
       postcss: 8.4.32
-      rollup: 4.9.1
+      rollup: 4.9.6
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.1.0(@types/node@20.10.5):
-    resolution: {integrity: sha512-oDFiCrw7dd3Jf06HoMtSRARivvyjHJaTxikFxuqJjO76U436PqlVw1uLn7a8OSPrhSfMGVaRakKpA2lePdw79A==}
+  /vitest@1.2.2(@types/node@20.11.10):
+    resolution: {integrity: sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -1584,13 +1609,13 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@types/node': 20.10.5
-      '@vitest/expect': 1.1.0
-      '@vitest/runner': 1.1.0
-      '@vitest/snapshot': 1.1.0
-      '@vitest/spy': 1.1.0
-      '@vitest/utils': 1.1.0
-      acorn-walk: 8.3.1
+      '@types/node': 20.11.10
+      '@vitest/expect': 1.2.2
+      '@vitest/runner': 1.2.2
+      '@vitest/snapshot': 1.2.2
+      '@vitest/spy': 1.2.2
+      '@vitest/utils': 1.2.2
+      acorn-walk: 8.3.2
       cac: 6.7.14
       chai: 4.3.10
       debug: 4.3.4
@@ -1602,9 +1627,9 @@ packages:
       std-env: 3.5.0
       strip-literal: 1.3.0
       tinybench: 2.5.1
-      tinypool: 0.8.1
-      vite: 5.0.10(@types/node@20.10.5)
-      vite-node: 1.1.0(@types/node@20.10.5)
+      tinypool: 0.8.2
+      vite: 5.0.10(@types/node@20.11.10)
+      vite-node: 1.2.2(@types/node@20.11.10)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,7 +36,6 @@ export default [
     external: [
       '@babel/core',
       '@babel/types',
-      '@babel/helper-module-imports',
       '@babel/generator',
       'crypto',
     ],

--- a/src/babel/core/create-registry.ts
+++ b/src/babel/core/create-registry.ts
@@ -1,11 +1,11 @@
-import type { StateContext } from './types';
 import type * as babel from '@babel/core';
 import * as t from '@babel/types';
-import { getImportIdentifier } from './get-import-identifier';
 import { IMPORT_REFRESH, IMPORT_REGISTRY } from './constants';
 import { getHotIdentifier } from './get-hot-identifier';
-import { generateViteHMRRequirement } from './get-vite-hmr-requirement';
+import { getImportIdentifier } from './get-import-identifier';
 import { getRootStatementPath } from './get-root-statement-path';
+import { generateViteHMRRequirement } from './get-vite-hmr-requirement';
+import type { StateContext } from './types';
 
 const REGISTRY = 'REGISTRY';
 
@@ -20,7 +20,7 @@ export function createRegistry(
   const root = getRootStatementPath(path);
   const identifier = path.scope.generateUidIdentifier(REGISTRY);
 
-  root.insertBefore(
+  const [tmp] = root.insertBefore(
     t.variableDeclaration('const', [
       t.variableDeclarator(
         identifier,
@@ -28,6 +28,7 @@ export function createRegistry(
       ),
     ]),
   );
+  root.scope.registerDeclaration(tmp);
   const pathToHot = getHotIdentifier(state);
   const statements: t.Statement[] = [
     t.expressionStatement(

--- a/src/babel/core/register-import-specifiers.ts
+++ b/src/babel/core/register-import-specifiers.ts
@@ -18,14 +18,13 @@ function registerImportSpecifier(
     return;
   }
   if (t.isImportSpecifier(specifier)) {
+    if (specifier.importKind === 'type' || specifier.importKind === 'typeof') {
+      return;
+    }
+    const name = getImportSpecifierName(specifier);
     if (
-      (!(
-        specifier.importKind === 'type' || specifier.importKind === 'typeof'
-      ) &&
-        id.definition.kind === 'named' &&
-        getImportSpecifierName(specifier) === id.definition.name) ||
-      (id.definition.kind === 'default' &&
-        getImportSpecifierName(specifier) === 'default')
+      (id.definition.kind === 'named' && name === id.definition.name) ||
+      (id.definition.kind === 'default' && name === 'default')
     ) {
       state.registrations.identifiers.set(specifier.local, id);
     }

--- a/src/babel/core/register-import-specifiers.ts
+++ b/src/babel/core/register-import-specifiers.ts
@@ -1,7 +1,7 @@
+import type * as babel from '@babel/core';
+import * as t from '@babel/types';
 import { getImportSpecifierName } from './checks';
 import type { ImportIdentifierSpecifier, StateContext } from './types';
-import * as t from '@babel/types';
-import type * as babel from '@babel/core';
 
 function registerImportSpecifier(
   state: StateContext,
@@ -19,7 +19,10 @@ function registerImportSpecifier(
   }
   if (t.isImportSpecifier(specifier)) {
     if (
-      (id.definition.kind === 'named' &&
+      (!(
+        specifier.importKind === 'type' || specifier.importKind === 'typeof'
+      ) &&
+        id.definition.kind === 'named' &&
         getImportSpecifierName(specifier) === id.definition.name) ||
       (id.definition.kind === 'default' &&
         getImportSpecifierName(specifier) === 'default')

--- a/src/babel/core/transform-jsx.ts
+++ b/src/babel/core/transform-jsx.ts
@@ -290,9 +290,11 @@ export function transformJSX(
     templateComp.loc = path.node.loc;
   }
 
-  rootPath.insertBefore(
+  const [tmp] = rootPath.insertBefore(
     t.variableDeclaration('const', [t.variableDeclarator(id, templateComp)]),
   );
+
+  rootPath.scope.registerDeclaration(tmp);
 
   path.replaceWith(
     skippableJSX(

--- a/src/babel/index.ts
+++ b/src/babel/index.ts
@@ -1,25 +1,25 @@
-import path from 'path';
 import type * as babel from '@babel/core';
 import * as t from '@babel/types';
-import { xxHash32 } from './core/xxhash32';
-import { registerImportSpecifiers } from './core/register-import-specifiers';
-import type { Options, StateContext } from './core/types';
+import path from 'path';
 import { isComponentishName } from './core/checks';
-import { getHMRDeclineCall } from './core/get-hmr-decline-call';
-import { unwrapNode } from './core/unwrap';
-import { isValidCallee } from './core/is-valid-callee';
-import { getHotIdentifier } from './core/get-hot-identifier';
-import { getStatementPath } from './core/get-statement-path';
-import { createRegistry } from './core/create-registry';
-import { getImportIdentifier } from './core/get-import-identifier';
 import {
   IMPORT_COMPONENT,
   IMPORT_CONTEXT,
   IMPORT_SPECIFIERS,
 } from './core/constants';
-import { getForeignBindings } from './core/get-foreign-bindings';
-import { transformJSX } from './core/transform-jsx';
+import { createRegistry } from './core/create-registry';
 import { generateCode } from './core/generator';
+import { getForeignBindings } from './core/get-foreign-bindings';
+import { getHMRDeclineCall } from './core/get-hmr-decline-call';
+import { getHotIdentifier } from './core/get-hot-identifier';
+import { getImportIdentifier } from './core/get-import-identifier';
+import { getStatementPath } from './core/get-statement-path';
+import { isValidCallee } from './core/is-valid-callee';
+import { registerImportSpecifiers } from './core/register-import-specifiers';
+import { transformJSX } from './core/transform-jsx';
+import type { Options, StateContext } from './core/types';
+import { unwrapNode } from './core/unwrap';
+import { xxHash32 } from './core/xxhash32';
 
 const CWD = process.cwd();
 
@@ -36,7 +36,7 @@ function createSignatureValue(node: t.Node): string {
 function captureIdentifiers(state: StateContext, path: babel.NodePath) {
   path.traverse({
     ImportDeclaration(p) {
-      if (p.node.importKind === 'value') {
+      if (!(p.node.importKind === 'type' || p.node.importKind === 'typeof')) {
         registerImportSpecifiers(state, p, state.specifiers);
       }
     },

--- a/src/babel/index.ts
+++ b/src/babel/index.ts
@@ -215,6 +215,12 @@ function isStatementTopLevel(path: babel.NodePath<t.Statement>): boolean {
   return programParent === blockParent;
 }
 
+function isValidFunction(
+  node: t.Node,
+): node is t.ArrowFunctionExpression | t.FunctionExpression {
+  return t.isArrowFunctionExpression(node) || t.isFunctionExpression(node);
+}
+
 function transformVariableDeclarator(
   state: StateContext,
   path: babel.NodePath<t.VariableDeclarator>,
@@ -231,9 +237,7 @@ function transformVariableDeclarator(
     return;
   }
   if (isComponentishName(identifier.name)) {
-    const trueFuncExpr =
-      unwrapNode(init, t.isFunctionExpression) ||
-      unwrapNode(init, t.isArrowFunctionExpression);
+    const trueFuncExpr = unwrapNode(init, isValidFunction);
     // Check for valid FunctionExpression or ArrowFunctionExpression
     if (
       trueFuncExpr &&
@@ -274,7 +278,7 @@ function transformFunctionDeclaration(
       // have zero or one parameter
       decl.params.length < 2
     ) {
-      path.replaceWith(
+      const [tmp] = path.replaceWith(
         t.variableDeclaration('const', [
           t.variableDeclarator(
             decl.id,
@@ -288,6 +292,7 @@ function transformFunctionDeclaration(
           ),
         ]),
       );
+      path.scope.registerDeclaration(tmp);
       path.skip();
     }
   }
@@ -312,6 +317,7 @@ function bubbleFunctionDeclaration(
     ) {
       const first = program.get('body')[0];
       const [tmp] = first.insertBefore(decl);
+      program.scope.registerDeclaration(tmp);
       tmp.skip();
       if (path.parentPath.isExportNamedDeclaration()) {
         path.parentPath.replaceWith(
@@ -360,7 +366,6 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
             bubbleFunctionDeclaration(programPath, path);
           },
         });
-        programPath.scope.crawl();
         programPath.traverse({
           JSXElement(path) {
             transformJSX(path);
@@ -369,7 +374,6 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
             transformJSX(path);
           },
         });
-        programPath.scope.crawl();
         programPath.traverse({
           VariableDeclarator(path) {
             transformVariableDeclarator(state, path);
@@ -378,7 +382,6 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
             transformFunctionDeclaration(state, path);
           },
         });
-        programPath.scope.crawl();
       },
     },
   };

--- a/tests/client-hydratable/__snapshots__/esm.test.ts.snap
+++ b/tests/client-hydratable/__snapshots__/esm.test.ts.snap
@@ -34,8 +34,8 @@ if (import.meta.hot) {
 exports[`esm (client, hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _$getNextElement(_tmpl$);
@@ -59,10 +59,10 @@ exports[`esm (client, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -80,10 +80,10 @@ exports[`esm (client, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -101,10 +101,10 @@ exports[`esm (client, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -126,10 +126,10 @@ exports[`esm (client, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -152,10 +152,10 @@ exports[`esm (client, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _$getNextElement(_tmpl$);
@@ -219,11 +219,11 @@ exports[`esm (client, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:8:12",
@@ -271,8 +271,8 @@ if (import.meta.hot) {
 exports[`esm (client, hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _$getNextElement(_tmpl$);
@@ -296,10 +296,10 @@ exports[`esm (client, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -321,10 +321,10 @@ exports[`esm (client, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -342,10 +342,10 @@ exports[`esm (client, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -367,10 +367,10 @@ exports[`esm (client, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -393,10 +393,10 @@ exports[`esm (client, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _$getNextElement(_tmpl$);
@@ -460,11 +460,11 @@ exports[`esm (client, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:8:12",
@@ -513,8 +513,8 @@ if (import.meta.hot) {
 exports[`esm (client, hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _$getNextElement(_tmpl$);
@@ -538,10 +538,10 @@ exports[`esm (client, hydratable) > FunctionDeclaration > should skip FunctionDe
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -559,10 +559,10 @@ exports[`esm (client, hydratable) > FunctionDeclaration > should skip FunctionDe
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -580,10 +580,10 @@ exports[`esm (client, hydratable) > FunctionDeclaration > should transform Funct
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -604,10 +604,10 @@ exports[`esm (client, hydratable) > FunctionDeclaration > should transform Funct
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -629,10 +629,10 @@ exports[`esm (client, hydratable) > FunctionDeclaration > should transform Funct
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -694,11 +694,11 @@ exports[`esm (client, hydratable) > FunctionDeclaration > should transform Funct
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -745,8 +745,8 @@ if (import.meta.hot) {
 exports[`esm (client, hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _$getNextElement(_tmpl$);
@@ -770,10 +770,10 @@ exports[`esm (client, hydratable) > VariableDeclarator > ArrowFunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -791,10 +791,10 @@ exports[`esm (client, hydratable) > VariableDeclarator > ArrowFunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -812,10 +812,10 @@ exports[`esm (client, hydratable) > VariableDeclarator > ArrowFunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -836,10 +836,10 @@ exports[`esm (client, hydratable) > VariableDeclarator > ArrowFunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -861,10 +861,10 @@ exports[`esm (client, hydratable) > VariableDeclarator > ArrowFunctionExpression
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -926,11 +926,11 @@ exports[`esm (client, hydratable) > VariableDeclarator > ArrowFunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -977,8 +977,8 @@ if (import.meta.hot) {
 exports[`esm (client, hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _$getNextElement(_tmpl$);
@@ -1002,10 +1002,10 @@ exports[`esm (client, hydratable) > VariableDeclarator > FunctionExpression > sh
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1023,10 +1023,10 @@ exports[`esm (client, hydratable) > VariableDeclarator > FunctionExpression > sh
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1044,10 +1044,10 @@ exports[`esm (client, hydratable) > VariableDeclarator > FunctionExpression > sh
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1068,10 +1068,10 @@ exports[`esm (client, hydratable) > VariableDeclarator > FunctionExpression > sh
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1093,10 +1093,10 @@ exports[`esm (client, hydratable) > VariableDeclarator > FunctionExpression > sh
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -1158,11 +1158,11 @@ exports[`esm (client, hydratable) > VariableDeclarator > FunctionExpression > sh
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",

--- a/tests/client-hydratable/__snapshots__/rspack-esm.test.ts.snap
+++ b/tests/client-hydratable/__snapshots__/rspack-esm.test.ts.snap
@@ -34,8 +34,8 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _$getNextElement(_tmpl$);
@@ -59,10 +59,10 @@ exports[`rspack-esm (client, hydratable) > ExportDefaultDeclaration w/ FunctionE
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -80,10 +80,10 @@ exports[`rspack-esm (client, hydratable) > ExportDefaultDeclaration w/ FunctionE
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -101,10 +101,10 @@ exports[`rspack-esm (client, hydratable) > ExportDefaultDeclaration w/ FunctionE
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -126,10 +126,10 @@ exports[`rspack-esm (client, hydratable) > ExportDefaultDeclaration w/ FunctionE
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -152,10 +152,10 @@ exports[`rspack-esm (client, hydratable) > ExportDefaultDeclaration w/ FunctionE
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _$getNextElement(_tmpl$);
@@ -219,11 +219,11 @@ exports[`rspack-esm (client, hydratable) > ExportDefaultDeclaration w/ FunctionE
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:8:12",
@@ -271,8 +271,8 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _$getNextElement(_tmpl$);
@@ -296,10 +296,10 @@ exports[`rspack-esm (client, hydratable) > ExportNamedDeclaration w/ FunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -321,10 +321,10 @@ exports[`rspack-esm (client, hydratable) > ExportNamedDeclaration w/ FunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -342,10 +342,10 @@ exports[`rspack-esm (client, hydratable) > ExportNamedDeclaration w/ FunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -367,10 +367,10 @@ exports[`rspack-esm (client, hydratable) > ExportNamedDeclaration w/ FunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -393,10 +393,10 @@ exports[`rspack-esm (client, hydratable) > ExportNamedDeclaration w/ FunctionExp
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _$getNextElement(_tmpl$);
@@ -460,11 +460,11 @@ exports[`rspack-esm (client, hydratable) > ExportNamedDeclaration w/ FunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:8:12",
@@ -513,8 +513,8 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _$getNextElement(_tmpl$);
@@ -538,10 +538,10 @@ exports[`rspack-esm (client, hydratable) > FunctionDeclaration > should skip Fun
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -559,10 +559,10 @@ exports[`rspack-esm (client, hydratable) > FunctionDeclaration > should skip Fun
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -580,10 +580,10 @@ exports[`rspack-esm (client, hydratable) > FunctionDeclaration > should transfor
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -604,10 +604,10 @@ exports[`rspack-esm (client, hydratable) > FunctionDeclaration > should transfor
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -629,10 +629,10 @@ exports[`rspack-esm (client, hydratable) > FunctionDeclaration > should transfor
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -694,11 +694,11 @@ exports[`rspack-esm (client, hydratable) > FunctionDeclaration > should transfor
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -745,8 +745,8 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _$getNextElement(_tmpl$);
@@ -770,10 +770,10 @@ exports[`rspack-esm (client, hydratable) > VariableDeclarator > ArrowFunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -791,10 +791,10 @@ exports[`rspack-esm (client, hydratable) > VariableDeclarator > ArrowFunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -812,10 +812,10 @@ exports[`rspack-esm (client, hydratable) > VariableDeclarator > ArrowFunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -836,10 +836,10 @@ exports[`rspack-esm (client, hydratable) > VariableDeclarator > ArrowFunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -861,10 +861,10 @@ exports[`rspack-esm (client, hydratable) > VariableDeclarator > ArrowFunctionExp
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -926,11 +926,11 @@ exports[`rspack-esm (client, hydratable) > VariableDeclarator > ArrowFunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -977,8 +977,8 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _$getNextElement(_tmpl$);
@@ -1002,10 +1002,10 @@ exports[`rspack-esm (client, hydratable) > VariableDeclarator > FunctionExpressi
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1023,10 +1023,10 @@ exports[`rspack-esm (client, hydratable) > VariableDeclarator > FunctionExpressi
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1044,10 +1044,10 @@ exports[`rspack-esm (client, hydratable) > VariableDeclarator > FunctionExpressi
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1068,10 +1068,10 @@ exports[`rspack-esm (client, hydratable) > VariableDeclarator > FunctionExpressi
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1093,10 +1093,10 @@ exports[`rspack-esm (client, hydratable) > VariableDeclarator > FunctionExpressi
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -1158,11 +1158,11 @@ exports[`rspack-esm (client, hydratable) > VariableDeclarator > FunctionExpressi
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",

--- a/tests/client-hydratable/__snapshots__/standard.test.ts.snap
+++ b/tests/client-hydratable/__snapshots__/standard.test.ts.snap
@@ -34,8 +34,8 @@ if (module.hot) {
 exports[`standard (client, hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _$getNextElement(_tmpl$);
@@ -59,10 +59,10 @@ exports[`standard (client, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -80,10 +80,10 @@ exports[`standard (client, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -101,10 +101,10 @@ exports[`standard (client, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -126,10 +126,10 @@ exports[`standard (client, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -152,10 +152,10 @@ exports[`standard (client, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _$getNextElement(_tmpl$);
@@ -219,11 +219,11 @@ exports[`standard (client, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:8:12",
@@ -271,8 +271,8 @@ if (module.hot) {
 exports[`standard (client, hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _$getNextElement(_tmpl$);
@@ -296,10 +296,10 @@ exports[`standard (client, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -321,10 +321,10 @@ exports[`standard (client, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -342,10 +342,10 @@ exports[`standard (client, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -367,10 +367,10 @@ exports[`standard (client, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -393,10 +393,10 @@ exports[`standard (client, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _$getNextElement(_tmpl$);
@@ -460,11 +460,11 @@ exports[`standard (client, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:8:12",
@@ -513,8 +513,8 @@ if (module.hot) {
 exports[`standard (client, hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _$getNextElement(_tmpl$);
@@ -538,10 +538,10 @@ exports[`standard (client, hydratable) > FunctionDeclaration > should skip Funct
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -559,10 +559,10 @@ exports[`standard (client, hydratable) > FunctionDeclaration > should skip Funct
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -580,10 +580,10 @@ exports[`standard (client, hydratable) > FunctionDeclaration > should transform 
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -604,10 +604,10 @@ exports[`standard (client, hydratable) > FunctionDeclaration > should transform 
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -629,10 +629,10 @@ exports[`standard (client, hydratable) > FunctionDeclaration > should transform 
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -694,11 +694,11 @@ exports[`standard (client, hydratable) > FunctionDeclaration > should transform 
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -745,8 +745,8 @@ if (module.hot) {
 exports[`standard (client, hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _$getNextElement(_tmpl$);
@@ -770,10 +770,10 @@ exports[`standard (client, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -791,10 +791,10 @@ exports[`standard (client, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -812,10 +812,10 @@ exports[`standard (client, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -836,10 +836,10 @@ exports[`standard (client, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -861,10 +861,10 @@ exports[`standard (client, hydratable) > VariableDeclarator > ArrowFunctionExpre
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -926,11 +926,11 @@ exports[`standard (client, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -977,8 +977,8 @@ if (module.hot) {
 exports[`standard (client, hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _$getNextElement(_tmpl$);
@@ -1002,10 +1002,10 @@ exports[`standard (client, hydratable) > VariableDeclarator > FunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1023,10 +1023,10 @@ exports[`standard (client, hydratable) > VariableDeclarator > FunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1044,10 +1044,10 @@ exports[`standard (client, hydratable) > VariableDeclarator > FunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1068,10 +1068,10 @@ exports[`standard (client, hydratable) > VariableDeclarator > FunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1093,10 +1093,10 @@ exports[`standard (client, hydratable) > VariableDeclarator > FunctionExpression
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -1158,11 +1158,11 @@ exports[`standard (client, hydratable) > VariableDeclarator > FunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",

--- a/tests/client-hydratable/__snapshots__/vite.test.ts.snap
+++ b/tests/client-hydratable/__snapshots__/vite.test.ts.snap
@@ -36,8 +36,8 @@ if (import.meta.hot) {
 exports[`vite (client, hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _$getNextElement(_tmpl$);
@@ -62,10 +62,10 @@ exports[`vite (client, hydratable) > ExportDefaultDeclaration w/ FunctionExpress
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -84,10 +84,10 @@ exports[`vite (client, hydratable) > ExportDefaultDeclaration w/ FunctionExpress
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -106,10 +106,10 @@ exports[`vite (client, hydratable) > ExportDefaultDeclaration w/ FunctionExpress
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -132,10 +132,10 @@ exports[`vite (client, hydratable) > ExportDefaultDeclaration w/ FunctionExpress
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -159,10 +159,10 @@ exports[`vite (client, hydratable) > ExportDefaultDeclaration w/ FunctionExpress
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _$getNextElement(_tmpl$);
@@ -228,11 +228,11 @@ exports[`vite (client, hydratable) > ExportDefaultDeclaration w/ FunctionExpress
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:8:12",
@@ -281,8 +281,8 @@ if (import.meta.hot) {
 exports[`vite (client, hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _$getNextElement(_tmpl$);
@@ -307,10 +307,10 @@ exports[`vite (client, hydratable) > ExportNamedDeclaration w/ FunctionExpressio
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -333,10 +333,10 @@ exports[`vite (client, hydratable) > ExportNamedDeclaration w/ FunctionExpressio
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -355,10 +355,10 @@ exports[`vite (client, hydratable) > ExportNamedDeclaration w/ FunctionExpressio
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -381,10 +381,10 @@ exports[`vite (client, hydratable) > ExportNamedDeclaration w/ FunctionExpressio
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -408,10 +408,10 @@ exports[`vite (client, hydratable) > ExportNamedDeclaration w/ FunctionExpressio
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _$getNextElement(_tmpl$);
@@ -477,11 +477,11 @@ exports[`vite (client, hydratable) > ExportNamedDeclaration w/ FunctionExpressio
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:8:12",
@@ -531,8 +531,8 @@ if (import.meta.hot) {
 exports[`vite (client, hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _$getNextElement(_tmpl$);
@@ -557,10 +557,10 @@ exports[`vite (client, hydratable) > FunctionDeclaration > should skip FunctionD
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -579,10 +579,10 @@ exports[`vite (client, hydratable) > FunctionDeclaration > should skip FunctionD
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -601,10 +601,10 @@ exports[`vite (client, hydratable) > FunctionDeclaration > should transform Func
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -626,10 +626,10 @@ exports[`vite (client, hydratable) > FunctionDeclaration > should transform Func
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -652,10 +652,10 @@ exports[`vite (client, hydratable) > FunctionDeclaration > should transform Func
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -719,11 +719,11 @@ exports[`vite (client, hydratable) > FunctionDeclaration > should transform Func
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -771,8 +771,8 @@ if (import.meta.hot) {
 exports[`vite (client, hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _$getNextElement(_tmpl$);
@@ -797,10 +797,10 @@ exports[`vite (client, hydratable) > VariableDeclarator > ArrowFunctionExpressio
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -819,10 +819,10 @@ exports[`vite (client, hydratable) > VariableDeclarator > ArrowFunctionExpressio
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -841,10 +841,10 @@ exports[`vite (client, hydratable) > VariableDeclarator > ArrowFunctionExpressio
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -866,10 +866,10 @@ exports[`vite (client, hydratable) > VariableDeclarator > ArrowFunctionExpressio
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -892,10 +892,10 @@ exports[`vite (client, hydratable) > VariableDeclarator > ArrowFunctionExpressio
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -959,11 +959,11 @@ exports[`vite (client, hydratable) > VariableDeclarator > ArrowFunctionExpressio
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1011,8 +1011,8 @@ if (import.meta.hot) {
 exports[`vite (client, hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _$getNextElement(_tmpl$);
@@ -1037,10 +1037,10 @@ exports[`vite (client, hydratable) > VariableDeclarator > FunctionExpression > s
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1059,10 +1059,10 @@ exports[`vite (client, hydratable) > VariableDeclarator > FunctionExpression > s
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1081,10 +1081,10 @@ exports[`vite (client, hydratable) > VariableDeclarator > FunctionExpression > s
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1106,10 +1106,10 @@ exports[`vite (client, hydratable) > VariableDeclarator > FunctionExpression > s
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1132,10 +1132,10 @@ exports[`vite (client, hydratable) > VariableDeclarator > FunctionExpression > s
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -1199,11 +1199,11 @@ exports[`vite (client, hydratable) > VariableDeclarator > FunctionExpression > s
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",

--- a/tests/client-hydratable/__snapshots__/webpack5.test.ts.snap
+++ b/tests/client-hydratable/__snapshots__/webpack5.test.ts.snap
@@ -34,8 +34,8 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _$getNextElement(_tmpl$);
@@ -59,10 +59,10 @@ exports[`webpack5 (client, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -80,10 +80,10 @@ exports[`webpack5 (client, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -101,10 +101,10 @@ exports[`webpack5 (client, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -126,10 +126,10 @@ exports[`webpack5 (client, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -152,10 +152,10 @@ exports[`webpack5 (client, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _$getNextElement(_tmpl$);
@@ -219,11 +219,11 @@ exports[`webpack5 (client, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:8:12",
@@ -271,8 +271,8 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _$getNextElement(_tmpl$);
@@ -296,10 +296,10 @@ exports[`webpack5 (client, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -321,10 +321,10 @@ exports[`webpack5 (client, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -342,10 +342,10 @@ exports[`webpack5 (client, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -367,10 +367,10 @@ exports[`webpack5 (client, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -393,10 +393,10 @@ exports[`webpack5 (client, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _$getNextElement(_tmpl$);
@@ -460,11 +460,11 @@ exports[`webpack5 (client, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:8:12",
@@ -513,8 +513,8 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _$getNextElement(_tmpl$);
@@ -538,10 +538,10 @@ exports[`webpack5 (client, hydratable) > FunctionDeclaration > should skip Funct
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -559,10 +559,10 @@ exports[`webpack5 (client, hydratable) > FunctionDeclaration > should skip Funct
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -580,10 +580,10 @@ exports[`webpack5 (client, hydratable) > FunctionDeclaration > should transform 
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -604,10 +604,10 @@ exports[`webpack5 (client, hydratable) > FunctionDeclaration > should transform 
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -629,10 +629,10 @@ exports[`webpack5 (client, hydratable) > FunctionDeclaration > should transform 
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -694,11 +694,11 @@ exports[`webpack5 (client, hydratable) > FunctionDeclaration > should transform 
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
@@ -745,8 +745,8 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _$getNextElement(_tmpl$);
@@ -770,10 +770,10 @@ exports[`webpack5 (client, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -791,10 +791,10 @@ exports[`webpack5 (client, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -812,10 +812,10 @@ exports[`webpack5 (client, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -836,10 +836,10 @@ exports[`webpack5 (client, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -861,10 +861,10 @@ exports[`webpack5 (client, hydratable) > VariableDeclarator > ArrowFunctionExpre
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -926,11 +926,11 @@ exports[`webpack5 (client, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -977,8 +977,8 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _$getNextElement(_tmpl$);
@@ -1002,10 +1002,10 @@ exports[`webpack5 (client, hydratable) > VariableDeclarator > FunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1023,10 +1023,10 @@ exports[`webpack5 (client, hydratable) > VariableDeclarator > FunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1044,10 +1044,10 @@ exports[`webpack5 (client, hydratable) > VariableDeclarator > FunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1068,10 +1068,10 @@ exports[`webpack5 (client, hydratable) > VariableDeclarator > FunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1093,10 +1093,10 @@ exports[`webpack5 (client, hydratable) > VariableDeclarator > FunctionExpression
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -1158,11 +1158,11 @@ exports[`webpack5 (client, hydratable) > VariableDeclarator > FunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:17",

--- a/tests/client/__snapshots__/esm.test.ts.snap
+++ b/tests/client/__snapshots__/esm.test.ts.snap
@@ -33,8 +33,8 @@ if (import.meta.hot) {
 
 exports[`esm (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _tmpl$();
@@ -56,10 +56,10 @@ export default function Foo() {
 exports[`esm (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -76,10 +76,10 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -96,10 +96,10 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -120,10 +120,10 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -145,10 +145,10 @@ exports[`esm (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpr
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _tmpl$();
@@ -211,11 +211,11 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:8:12",
@@ -262,8 +262,8 @@ if (import.meta.hot) {
 
 exports[`esm (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _tmpl$();
@@ -285,10 +285,10 @@ export function Foo() {
 exports[`esm (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -309,10 +309,10 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -329,10 +329,10 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -353,10 +353,10 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -378,10 +378,10 @@ exports[`esm (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpres
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _tmpl$();
@@ -444,11 +444,11 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:8:12",
@@ -496,8 +496,8 @@ if (import.meta.hot) {
 
 exports[`esm (client, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _tmpl$();
@@ -519,10 +519,10 @@ function Foo() {
 exports[`esm (client, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -539,10 +539,10 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -559,10 +559,10 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -582,10 +582,10 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -606,10 +606,10 @@ exports[`esm (client, non-hydratable) > FunctionDeclaration > should transform F
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -670,11 +670,11 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -720,8 +720,8 @@ if (import.meta.hot) {
 
 exports[`esm (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _tmpl$();
@@ -743,10 +743,10 @@ const Foo = () => {
 exports[`esm (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -763,10 +763,10 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -783,10 +783,10 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -806,10 +806,10 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -830,10 +830,10 @@ exports[`esm (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpres
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -894,11 +894,11 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -944,8 +944,8 @@ if (import.meta.hot) {
 
 exports[`esm (client, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _tmpl$();
@@ -967,10 +967,10 @@ const Foo = function () {
 exports[`esm (client, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -987,10 +987,10 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -1007,10 +1007,10 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -1030,10 +1030,10 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -1054,10 +1054,10 @@ exports[`esm (client, non-hydratable) > VariableDeclarator > FunctionExpression 
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -1118,11 +1118,11 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",

--- a/tests/client/__snapshots__/rspack-esm.test.ts.snap
+++ b/tests/client/__snapshots__/rspack-esm.test.ts.snap
@@ -33,8 +33,8 @@ if (import.meta.webpackHot) {
 
 exports[`rspack-esm (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _tmpl$();
@@ -56,10 +56,10 @@ export default function Foo() {
 exports[`rspack-esm (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -76,10 +76,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -96,10 +96,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -120,10 +120,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -145,10 +145,10 @@ exports[`rspack-esm (client, non-hydratable) > ExportDefaultDeclaration w/ Funct
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _tmpl$();
@@ -211,11 +211,11 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:8:12",
@@ -262,8 +262,8 @@ if (import.meta.webpackHot) {
 
 exports[`rspack-esm (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _tmpl$();
@@ -285,10 +285,10 @@ export function Foo() {
 exports[`rspack-esm (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -309,10 +309,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -329,10 +329,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -353,10 +353,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -378,10 +378,10 @@ exports[`rspack-esm (client, non-hydratable) > ExportNamedDeclaration w/ Functio
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _tmpl$();
@@ -444,11 +444,11 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:8:12",
@@ -496,8 +496,8 @@ if (import.meta.webpackHot) {
 
 exports[`rspack-esm (client, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _tmpl$();
@@ -519,10 +519,10 @@ function Foo() {
 exports[`rspack-esm (client, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -539,10 +539,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -559,10 +559,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -582,10 +582,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -606,10 +606,10 @@ exports[`rspack-esm (client, non-hydratable) > FunctionDeclaration > should tran
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -670,11 +670,11 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -720,8 +720,8 @@ if (import.meta.webpackHot) {
 
 exports[`rspack-esm (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _tmpl$();
@@ -743,10 +743,10 @@ const Foo = () => {
 exports[`rspack-esm (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -763,10 +763,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -783,10 +783,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -806,10 +806,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -830,10 +830,10 @@ exports[`rspack-esm (client, non-hydratable) > VariableDeclarator > ArrowFunctio
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -894,11 +894,11 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -944,8 +944,8 @@ if (import.meta.webpackHot) {
 
 exports[`rspack-esm (client, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _tmpl$();
@@ -967,10 +967,10 @@ const Foo = function () {
 exports[`rspack-esm (client, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -987,10 +987,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -1007,10 +1007,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -1030,10 +1030,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -1054,10 +1054,10 @@ exports[`rspack-esm (client, non-hydratable) > VariableDeclarator > FunctionExpr
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -1118,11 +1118,11 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",

--- a/tests/client/__snapshots__/standard.test.ts.snap
+++ b/tests/client/__snapshots__/standard.test.ts.snap
@@ -33,8 +33,8 @@ if (module.hot) {
 
 exports[`standard (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _tmpl$();
@@ -56,10 +56,10 @@ export default function Foo() {
 exports[`standard (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -76,10 +76,10 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -96,10 +96,10 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -120,10 +120,10 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -145,10 +145,10 @@ exports[`standard (client, non-hydratable) > ExportDefaultDeclaration w/ Functio
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _tmpl$();
@@ -211,11 +211,11 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:8:12",
@@ -262,8 +262,8 @@ if (module.hot) {
 
 exports[`standard (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _tmpl$();
@@ -285,10 +285,10 @@ export function Foo() {
 exports[`standard (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -309,10 +309,10 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -329,10 +329,10 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -353,10 +353,10 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -378,10 +378,10 @@ exports[`standard (client, non-hydratable) > ExportNamedDeclaration w/ FunctionE
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _tmpl$();
@@ -444,11 +444,11 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:8:12",
@@ -496,8 +496,8 @@ if (module.hot) {
 
 exports[`standard (client, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _tmpl$();
@@ -519,10 +519,10 @@ function Foo() {
 exports[`standard (client, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -539,10 +539,10 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -559,10 +559,10 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -582,10 +582,10 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -606,10 +606,10 @@ exports[`standard (client, non-hydratable) > FunctionDeclaration > should transf
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -670,11 +670,11 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -720,8 +720,8 @@ if (module.hot) {
 
 exports[`standard (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _tmpl$();
@@ -743,10 +743,10 @@ const Foo = () => {
 exports[`standard (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -763,10 +763,10 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -783,10 +783,10 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -806,10 +806,10 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -830,10 +830,10 @@ exports[`standard (client, non-hydratable) > VariableDeclarator > ArrowFunctionE
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -894,11 +894,11 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -944,8 +944,8 @@ if (module.hot) {
 
 exports[`standard (client, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _tmpl$();
@@ -967,10 +967,10 @@ const Foo = function () {
 exports[`standard (client, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -987,10 +987,10 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -1007,10 +1007,10 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -1030,10 +1030,10 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -1054,10 +1054,10 @@ exports[`standard (client, non-hydratable) > VariableDeclarator > FunctionExpres
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -1118,11 +1118,11 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",

--- a/tests/client/__snapshots__/vite.test.ts.snap
+++ b/tests/client/__snapshots__/vite.test.ts.snap
@@ -35,8 +35,8 @@ if (import.meta.hot) {
 
 exports[`vite (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _tmpl$();
@@ -59,10 +59,10 @@ export default function Foo() {
 exports[`vite (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -80,10 +80,10 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -101,10 +101,10 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -126,10 +126,10 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -152,10 +152,10 @@ exports[`vite (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _tmpl$();
@@ -220,11 +220,11 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:8:12",
@@ -272,8 +272,8 @@ if (import.meta.hot) {
 
 exports[`vite (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _tmpl$();
@@ -296,10 +296,10 @@ export function Foo() {
 exports[`vite (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -321,10 +321,10 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -342,10 +342,10 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -367,10 +367,10 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -393,10 +393,10 @@ exports[`vite (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _tmpl$();
@@ -461,11 +461,11 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:8:12",
@@ -514,8 +514,8 @@ if (import.meta.hot) {
 
 exports[`vite (client, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _tmpl$();
@@ -538,10 +538,10 @@ function Foo() {
 exports[`vite (client, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -559,10 +559,10 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -580,10 +580,10 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -604,10 +604,10 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -629,10 +629,10 @@ exports[`vite (client, non-hydratable) > FunctionDeclaration > should transform 
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -695,11 +695,11 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -746,8 +746,8 @@ if (import.meta.hot) {
 
 exports[`vite (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _tmpl$();
@@ -770,10 +770,10 @@ const Foo = () => {
 exports[`vite (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -791,10 +791,10 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -812,10 +812,10 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -836,10 +836,10 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -861,10 +861,10 @@ exports[`vite (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -927,11 +927,11 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -978,8 +978,8 @@ if (import.meta.hot) {
 
 exports[`vite (client, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _tmpl$();
@@ -1002,10 +1002,10 @@ const Foo = function () {
 exports[`vite (client, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -1023,10 +1023,10 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -1044,10 +1044,10 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -1068,10 +1068,10 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -1093,10 +1093,10 @@ exports[`vite (client, non-hydratable) > VariableDeclarator > FunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -1159,11 +1159,11 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",

--- a/tests/client/__snapshots__/webpack5.test.ts.snap
+++ b/tests/client/__snapshots__/webpack5.test.ts.snap
@@ -33,8 +33,8 @@ if (import.meta.webpackHot) {
 
 exports[`webpack5 (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _tmpl$();
@@ -56,10 +56,10 @@ export default function Foo() {
 exports[`webpack5 (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -76,10 +76,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -96,10 +96,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -120,10 +120,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -145,10 +145,10 @@ exports[`webpack5 (client, non-hydratable) > ExportDefaultDeclaration w/ Functio
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _tmpl$();
@@ -211,11 +211,11 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:8:12",
@@ -262,8 +262,8 @@ if (import.meta.webpackHot) {
 
 exports[`webpack5 (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _tmpl$();
@@ -285,10 +285,10 @@ export function Foo() {
 exports[`webpack5 (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -309,10 +309,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -329,10 +329,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -353,10 +353,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -378,10 +378,10 @@ exports[`webpack5 (client, non-hydratable) > ExportNamedDeclaration w/ FunctionE
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _tmpl$();
@@ -444,11 +444,11 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:8:12",
@@ -496,8 +496,8 @@ if (import.meta.webpackHot) {
 
 exports[`webpack5 (client, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _tmpl$();
@@ -519,10 +519,10 @@ function Foo() {
 exports[`webpack5 (client, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -539,10 +539,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -559,10 +559,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -582,10 +582,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -606,10 +606,10 @@ exports[`webpack5 (client, non-hydratable) > FunctionDeclaration > should transf
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -670,11 +670,11 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
@@ -720,8 +720,8 @@ if (import.meta.webpackHot) {
 
 exports[`webpack5 (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _tmpl$();
@@ -743,10 +743,10 @@ const Foo = () => {
 exports[`webpack5 (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -763,10 +763,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -783,10 +783,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -806,10 +806,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -830,10 +830,10 @@ exports[`webpack5 (client, non-hydratable) > VariableDeclarator > ArrowFunctionE
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -894,11 +894,11 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -944,8 +944,8 @@ if (import.meta.webpackHot) {
 
 exports[`webpack5 (client, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { template as _$template } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _tmpl$();
@@ -967,10 +967,10 @@ const Foo = function () {
 exports[`webpack5 (client, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with invalid Component name 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -987,10 +987,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -1007,10 +1007,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 1`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -1030,10 +1030,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 2`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>Foo\`);
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",
@@ -1054,10 +1054,10 @@ exports[`webpack5 (client, non-hydratable) > VariableDeclarator > FunctionExpres
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { insert as _$insert } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
@@ -1118,11 +1118,11 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:17",

--- a/tests/server-hydratable/__snapshots__/esm.test.ts.snap
+++ b/tests/server-hydratable/__snapshots__/esm.test.ts.snap
@@ -34,8 +34,8 @@ if (import.meta.hot) {
 exports[`esm (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -59,10 +59,10 @@ exports[`esm (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -80,10 +80,10 @@ exports[`esm (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -101,10 +101,10 @@ exports[`esm (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -126,10 +126,10 @@ exports[`esm (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -152,10 +152,10 @@ exports[`esm (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -215,11 +215,11 @@ exports[`esm (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">foo</div>"],
+  _tmpl$2 = ["<div", ">bar</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">foo</div>"],
-  _tmpl$2 = ["<div", ">bar</div>"];
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:8:12",
@@ -267,8 +267,8 @@ if (import.meta.hot) {
 exports[`esm (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -292,10 +292,10 @@ exports[`esm (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -317,10 +317,10 @@ exports[`esm (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -338,10 +338,10 @@ exports[`esm (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -363,10 +363,10 @@ exports[`esm (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -389,10 +389,10 @@ exports[`esm (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -452,11 +452,11 @@ exports[`esm (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">foo</div>"],
+  _tmpl$2 = ["<div", ">bar</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">foo</div>"],
-  _tmpl$2 = ["<div", ">bar</div>"];
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:8:12",
@@ -505,8 +505,8 @@ if (import.meta.hot) {
 exports[`esm (server, hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -530,10 +530,10 @@ exports[`esm (server, hydratable) > FunctionDeclaration > should skip FunctionDe
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -551,10 +551,10 @@ exports[`esm (server, hydratable) > FunctionDeclaration > should skip FunctionDe
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -572,10 +572,10 @@ exports[`esm (server, hydratable) > FunctionDeclaration > should transform Funct
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -596,10 +596,10 @@ exports[`esm (server, hydratable) > FunctionDeclaration > should transform Funct
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -621,10 +621,10 @@ exports[`esm (server, hydratable) > FunctionDeclaration > should transform Funct
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
@@ -682,11 +682,11 @@ exports[`esm (server, hydratable) > FunctionDeclaration > should transform Funct
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -733,8 +733,8 @@ if (import.meta.hot) {
 exports[`esm (server, hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -758,10 +758,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > ArrowFunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -779,10 +779,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > ArrowFunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -800,10 +800,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > ArrowFunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -824,10 +824,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > ArrowFunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -849,10 +849,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > ArrowFunctionExpression
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
@@ -910,11 +910,11 @@ exports[`esm (server, hydratable) > VariableDeclarator > ArrowFunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -961,8 +961,8 @@ if (import.meta.hot) {
 exports[`esm (server, hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -986,10 +986,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > FunctionExpression > sh
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1007,10 +1007,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > FunctionExpression > sh
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1028,10 +1028,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > FunctionExpression > sh
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1052,10 +1052,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > FunctionExpression > sh
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1077,10 +1077,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > FunctionExpression > sh
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
@@ -1138,11 +1138,11 @@ exports[`esm (server, hydratable) > VariableDeclarator > FunctionExpression > sh
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",

--- a/tests/server-hydratable/__snapshots__/rspack-esm.test.ts.snap
+++ b/tests/server-hydratable/__snapshots__/rspack-esm.test.ts.snap
@@ -34,8 +34,8 @@ if (import.meta.hot) {
 exports[`esm (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -59,10 +59,10 @@ exports[`esm (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -80,10 +80,10 @@ exports[`esm (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -101,10 +101,10 @@ exports[`esm (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -126,10 +126,10 @@ exports[`esm (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -152,10 +152,10 @@ exports[`esm (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -215,11 +215,11 @@ exports[`esm (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpressi
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">foo</div>"],
+  _tmpl$2 = ["<div", ">bar</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">foo</div>"],
-  _tmpl$2 = ["<div", ">bar</div>"];
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:8:12",
@@ -267,8 +267,8 @@ if (import.meta.hot) {
 exports[`esm (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -292,10 +292,10 @@ exports[`esm (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -317,10 +317,10 @@ exports[`esm (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -338,10 +338,10 @@ exports[`esm (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -363,10 +363,10 @@ exports[`esm (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -389,10 +389,10 @@ exports[`esm (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -452,11 +452,11 @@ exports[`esm (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">foo</div>"],
+  _tmpl$2 = ["<div", ">bar</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">foo</div>"],
-  _tmpl$2 = ["<div", ">bar</div>"];
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:8:12",
@@ -505,8 +505,8 @@ if (import.meta.hot) {
 exports[`esm (server, hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -530,10 +530,10 @@ exports[`esm (server, hydratable) > FunctionDeclaration > should skip FunctionDe
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -551,10 +551,10 @@ exports[`esm (server, hydratable) > FunctionDeclaration > should skip FunctionDe
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -572,10 +572,10 @@ exports[`esm (server, hydratable) > FunctionDeclaration > should transform Funct
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -596,10 +596,10 @@ exports[`esm (server, hydratable) > FunctionDeclaration > should transform Funct
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -621,10 +621,10 @@ exports[`esm (server, hydratable) > FunctionDeclaration > should transform Funct
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
@@ -682,11 +682,11 @@ exports[`esm (server, hydratable) > FunctionDeclaration > should transform Funct
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -733,8 +733,8 @@ if (import.meta.hot) {
 exports[`esm (server, hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -758,10 +758,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > ArrowFunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -779,10 +779,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > ArrowFunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -800,10 +800,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > ArrowFunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -824,10 +824,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > ArrowFunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -849,10 +849,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > ArrowFunctionExpression
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
@@ -910,11 +910,11 @@ exports[`esm (server, hydratable) > VariableDeclarator > ArrowFunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -961,8 +961,8 @@ if (import.meta.hot) {
 exports[`esm (server, hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -986,10 +986,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > FunctionExpression > sh
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1007,10 +1007,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > FunctionExpression > sh
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1028,10 +1028,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > FunctionExpression > sh
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1052,10 +1052,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > FunctionExpression > sh
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1077,10 +1077,10 @@ exports[`esm (server, hydratable) > VariableDeclarator > FunctionExpression > sh
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
@@ -1138,11 +1138,11 @@ exports[`esm (server, hydratable) > VariableDeclarator > FunctionExpression > sh
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",

--- a/tests/server-hydratable/__snapshots__/standard.test.ts.snap
+++ b/tests/server-hydratable/__snapshots__/standard.test.ts.snap
@@ -34,8 +34,8 @@ if (module.hot) {
 exports[`standard (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -59,10 +59,10 @@ exports[`standard (server, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -80,10 +80,10 @@ exports[`standard (server, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -101,10 +101,10 @@ exports[`standard (server, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -126,10 +126,10 @@ exports[`standard (server, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -152,10 +152,10 @@ exports[`standard (server, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -215,11 +215,11 @@ exports[`standard (server, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">foo</div>"],
+  _tmpl$2 = ["<div", ">bar</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">foo</div>"],
-  _tmpl$2 = ["<div", ">bar</div>"];
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:8:12",
@@ -267,8 +267,8 @@ if (module.hot) {
 exports[`standard (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -292,10 +292,10 @@ exports[`standard (server, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -317,10 +317,10 @@ exports[`standard (server, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -338,10 +338,10 @@ exports[`standard (server, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -363,10 +363,10 @@ exports[`standard (server, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -389,10 +389,10 @@ exports[`standard (server, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -452,11 +452,11 @@ exports[`standard (server, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">foo</div>"],
+  _tmpl$2 = ["<div", ">bar</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">foo</div>"],
-  _tmpl$2 = ["<div", ">bar</div>"];
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:8:12",
@@ -505,8 +505,8 @@ if (module.hot) {
 exports[`standard (server, hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -530,10 +530,10 @@ exports[`standard (server, hydratable) > FunctionDeclaration > should skip Funct
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -551,10 +551,10 @@ exports[`standard (server, hydratable) > FunctionDeclaration > should skip Funct
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -572,10 +572,10 @@ exports[`standard (server, hydratable) > FunctionDeclaration > should transform 
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -596,10 +596,10 @@ exports[`standard (server, hydratable) > FunctionDeclaration > should transform 
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -621,10 +621,10 @@ exports[`standard (server, hydratable) > FunctionDeclaration > should transform 
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
@@ -682,11 +682,11 @@ exports[`standard (server, hydratable) > FunctionDeclaration > should transform 
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -733,8 +733,8 @@ if (module.hot) {
 exports[`standard (server, hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -758,10 +758,10 @@ exports[`standard (server, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -779,10 +779,10 @@ exports[`standard (server, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -800,10 +800,10 @@ exports[`standard (server, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -824,10 +824,10 @@ exports[`standard (server, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -849,10 +849,10 @@ exports[`standard (server, hydratable) > VariableDeclarator > ArrowFunctionExpre
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
@@ -910,11 +910,11 @@ exports[`standard (server, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -961,8 +961,8 @@ if (module.hot) {
 exports[`standard (server, hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -986,10 +986,10 @@ exports[`standard (server, hydratable) > VariableDeclarator > FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1007,10 +1007,10 @@ exports[`standard (server, hydratable) > VariableDeclarator > FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1028,10 +1028,10 @@ exports[`standard (server, hydratable) > VariableDeclarator > FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1052,10 +1052,10 @@ exports[`standard (server, hydratable) > VariableDeclarator > FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1077,10 +1077,10 @@ exports[`standard (server, hydratable) > VariableDeclarator > FunctionExpression
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
@@ -1138,11 +1138,11 @@ exports[`standard (server, hydratable) > VariableDeclarator > FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",

--- a/tests/server-hydratable/__snapshots__/vite.test.ts.snap
+++ b/tests/server-hydratable/__snapshots__/vite.test.ts.snap
@@ -36,8 +36,8 @@ if (import.meta.hot) {
 exports[`vite (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -62,10 +62,10 @@ exports[`vite (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpress
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -84,10 +84,10 @@ exports[`vite (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpress
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -106,10 +106,10 @@ exports[`vite (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpress
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -132,10 +132,10 @@ exports[`vite (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpress
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -159,10 +159,10 @@ exports[`vite (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpress
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -224,11 +224,11 @@ exports[`vite (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpress
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">foo</div>"],
+  _tmpl$2 = ["<div", ">bar</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">foo</div>"],
-  _tmpl$2 = ["<div", ">bar</div>"];
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:8:12",
@@ -277,8 +277,8 @@ if (import.meta.hot) {
 exports[`vite (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -303,10 +303,10 @@ exports[`vite (server, hydratable) > ExportNamedDeclaration w/ FunctionExpressio
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -329,10 +329,10 @@ exports[`vite (server, hydratable) > ExportNamedDeclaration w/ FunctionExpressio
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -351,10 +351,10 @@ exports[`vite (server, hydratable) > ExportNamedDeclaration w/ FunctionExpressio
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -377,10 +377,10 @@ exports[`vite (server, hydratable) > ExportNamedDeclaration w/ FunctionExpressio
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -404,10 +404,10 @@ exports[`vite (server, hydratable) > ExportNamedDeclaration w/ FunctionExpressio
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -469,11 +469,11 @@ exports[`vite (server, hydratable) > ExportNamedDeclaration w/ FunctionExpressio
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">foo</div>"],
+  _tmpl$2 = ["<div", ">bar</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">foo</div>"],
-  _tmpl$2 = ["<div", ">bar</div>"];
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:8:12",
@@ -523,8 +523,8 @@ if (import.meta.hot) {
 exports[`vite (server, hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -549,10 +549,10 @@ exports[`vite (server, hydratable) > FunctionDeclaration > should skip FunctionD
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -571,10 +571,10 @@ exports[`vite (server, hydratable) > FunctionDeclaration > should skip FunctionD
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -593,10 +593,10 @@ exports[`vite (server, hydratable) > FunctionDeclaration > should transform Func
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -618,10 +618,10 @@ exports[`vite (server, hydratable) > FunctionDeclaration > should transform Func
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -644,10 +644,10 @@ exports[`vite (server, hydratable) > FunctionDeclaration > should transform Func
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
@@ -707,11 +707,11 @@ exports[`vite (server, hydratable) > FunctionDeclaration > should transform Func
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -759,8 +759,8 @@ if (import.meta.hot) {
 exports[`vite (server, hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -785,10 +785,10 @@ exports[`vite (server, hydratable) > VariableDeclarator > ArrowFunctionExpressio
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -807,10 +807,10 @@ exports[`vite (server, hydratable) > VariableDeclarator > ArrowFunctionExpressio
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -829,10 +829,10 @@ exports[`vite (server, hydratable) > VariableDeclarator > ArrowFunctionExpressio
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -854,10 +854,10 @@ exports[`vite (server, hydratable) > VariableDeclarator > ArrowFunctionExpressio
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -880,10 +880,10 @@ exports[`vite (server, hydratable) > VariableDeclarator > ArrowFunctionExpressio
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
@@ -943,11 +943,11 @@ exports[`vite (server, hydratable) > VariableDeclarator > ArrowFunctionExpressio
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -995,8 +995,8 @@ if (import.meta.hot) {
 exports[`vite (server, hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -1021,10 +1021,10 @@ exports[`vite (server, hydratable) > VariableDeclarator > FunctionExpression > s
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1043,10 +1043,10 @@ exports[`vite (server, hydratable) > VariableDeclarator > FunctionExpression > s
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1065,10 +1065,10 @@ exports[`vite (server, hydratable) > VariableDeclarator > FunctionExpression > s
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1090,10 +1090,10 @@ exports[`vite (server, hydratable) > VariableDeclarator > FunctionExpression > s
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1116,10 +1116,10 @@ exports[`vite (server, hydratable) > VariableDeclarator > FunctionExpression > s
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
@@ -1179,11 +1179,11 @@ exports[`vite (server, hydratable) > VariableDeclarator > FunctionExpression > s
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",

--- a/tests/server-hydratable/__snapshots__/webpack5.test.ts.snap
+++ b/tests/server-hydratable/__snapshots__/webpack5.test.ts.snap
@@ -34,8 +34,8 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -59,10 +59,10 @@ exports[`webpack5 (server, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -80,10 +80,10 @@ exports[`webpack5 (server, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -101,10 +101,10 @@ exports[`webpack5 (server, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -126,10 +126,10 @@ exports[`webpack5 (server, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -152,10 +152,10 @@ exports[`webpack5 (server, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -215,11 +215,11 @@ exports[`webpack5 (server, hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">foo</div>"],
+  _tmpl$2 = ["<div", ">bar</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">foo</div>"],
-  _tmpl$2 = ["<div", ">bar</div>"];
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:8:12",
@@ -267,8 +267,8 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -292,10 +292,10 @@ exports[`webpack5 (server, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -317,10 +317,10 @@ exports[`webpack5 (server, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -338,10 +338,10 @@ exports[`webpack5 (server, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -363,10 +363,10 @@ exports[`webpack5 (server, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -389,10 +389,10 @@ exports[`webpack5 (server, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -452,11 +452,11 @@ exports[`webpack5 (server, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">foo</div>"],
+  _tmpl$2 = ["<div", ">bar</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">foo</div>"],
-  _tmpl$2 = ["<div", ">bar</div>"];
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:8:12",
@@ -505,8 +505,8 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -530,10 +530,10 @@ exports[`webpack5 (server, hydratable) > FunctionDeclaration > should skip Funct
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -551,10 +551,10 @@ exports[`webpack5 (server, hydratable) > FunctionDeclaration > should skip Funct
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -572,10 +572,10 @@ exports[`webpack5 (server, hydratable) > FunctionDeclaration > should transform 
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -596,10 +596,10 @@ exports[`webpack5 (server, hydratable) > FunctionDeclaration > should transform 
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -621,10 +621,10 @@ exports[`webpack5 (server, hydratable) > FunctionDeclaration > should transform 
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
@@ -682,11 +682,11 @@ exports[`webpack5 (server, hydratable) > FunctionDeclaration > should transform 
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
@@ -733,8 +733,8 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -758,10 +758,10 @@ exports[`webpack5 (server, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -779,10 +779,10 @@ exports[`webpack5 (server, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -800,10 +800,10 @@ exports[`webpack5 (server, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -824,10 +824,10 @@ exports[`webpack5 (server, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -849,10 +849,10 @@ exports[`webpack5 (server, hydratable) > VariableDeclarator > ArrowFunctionExpre
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
@@ -910,11 +910,11 @@ exports[`webpack5 (server, hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -961,8 +961,8 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = ["<h1", ">Foo</h1>"];
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _$ssr(_tmpl$, _$ssrHydrationKey());
@@ -986,10 +986,10 @@ exports[`webpack5 (server, hydratable) > VariableDeclarator > FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1007,10 +1007,10 @@ exports[`webpack5 (server, hydratable) > VariableDeclarator > FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1028,10 +1028,10 @@ exports[`webpack5 (server, hydratable) > VariableDeclarator > FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1052,10 +1052,10 @@ exports[`webpack5 (server, hydratable) > VariableDeclarator > FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">Foo</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">Foo</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",
@@ -1077,10 +1077,10 @@ exports[`webpack5 (server, hydratable) > VariableDeclarator > FunctionExpression
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1", ">", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
@@ -1138,11 +1138,11 @@ exports[`webpack5 (server, hydratable) > VariableDeclarator > FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:17",

--- a/tests/server/__snapshots__/esm.test.ts.snap
+++ b/tests/server/__snapshots__/esm.test.ts.snap
@@ -33,8 +33,8 @@ if (import.meta.hot) {
 
 exports[`esm (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _$ssr(_tmpl$);
@@ -56,10 +56,10 @@ export default function Foo() {
 exports[`esm (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -76,10 +76,10 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -96,10 +96,10 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -120,10 +120,10 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -145,10 +145,10 @@ exports[`esm (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpr
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -207,11 +207,11 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>foo</div>",
+  _tmpl$2 = "<div>bar</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>foo</div>",
-  _tmpl$2 = "<div>bar</div>";
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:8:12",
@@ -258,8 +258,8 @@ if (import.meta.hot) {
 
 exports[`esm (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _$ssr(_tmpl$);
@@ -281,10 +281,10 @@ export function Foo() {
 exports[`esm (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -305,10 +305,10 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -325,10 +325,10 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -349,10 +349,10 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -374,10 +374,10 @@ exports[`esm (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpres
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -436,11 +436,11 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>foo</div>",
+  _tmpl$2 = "<div>bar</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>foo</div>",
-  _tmpl$2 = "<div>bar</div>";
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:8:12",
@@ -488,8 +488,8 @@ if (import.meta.hot) {
 
 exports[`esm (server, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _$ssr(_tmpl$);
@@ -511,10 +511,10 @@ function Foo() {
 exports[`esm (server, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -531,10 +531,10 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -551,10 +551,10 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:13",
@@ -574,10 +574,10 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -598,10 +598,10 @@ exports[`esm (server, non-hydratable) > FunctionDeclaration > should transform F
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
@@ -658,11 +658,11 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -708,8 +708,8 @@ if (import.meta.hot) {
 
 exports[`esm (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _$ssr(_tmpl$);
@@ -731,10 +731,10 @@ const Foo = () => {
 exports[`esm (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -751,10 +751,10 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -771,10 +771,10 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -794,10 +794,10 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -818,10 +818,10 @@ exports[`esm (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpres
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
@@ -878,11 +878,11 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -928,8 +928,8 @@ if (import.meta.hot) {
 
 exports[`esm (server, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _$ssr(_tmpl$);
@@ -951,10 +951,10 @@ const Foo = function () {
 exports[`esm (server, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -971,10 +971,10 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -991,10 +991,10 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1014,10 +1014,10 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1038,10 +1038,10 @@ exports[`esm (server, non-hydratable) > VariableDeclarator > FunctionExpression 
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
@@ -1098,11 +1098,11 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",

--- a/tests/server/__snapshots__/rspack-esm.test.ts.snap
+++ b/tests/server/__snapshots__/rspack-esm.test.ts.snap
@@ -33,8 +33,8 @@ if (import.meta.webpackHot) {
 
 exports[`rspack-esm (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _$ssr(_tmpl$);
@@ -56,10 +56,10 @@ export default function Foo() {
 exports[`rspack-esm (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -76,10 +76,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -96,10 +96,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -120,10 +120,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -145,10 +145,10 @@ exports[`rspack-esm (server, non-hydratable) > ExportDefaultDeclaration w/ Funct
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -207,11 +207,11 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>foo</div>",
+  _tmpl$2 = "<div>bar</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>foo</div>",
-  _tmpl$2 = "<div>bar</div>";
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:8:12",
@@ -258,8 +258,8 @@ if (import.meta.webpackHot) {
 
 exports[`rspack-esm (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _$ssr(_tmpl$);
@@ -281,10 +281,10 @@ export function Foo() {
 exports[`rspack-esm (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -305,10 +305,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -325,10 +325,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -349,10 +349,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -374,10 +374,10 @@ exports[`rspack-esm (server, non-hydratable) > ExportNamedDeclaration w/ Functio
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -436,11 +436,11 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>foo</div>",
+  _tmpl$2 = "<div>bar</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>foo</div>",
-  _tmpl$2 = "<div>bar</div>";
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:8:12",
@@ -488,8 +488,8 @@ if (import.meta.webpackHot) {
 
 exports[`rspack-esm (server, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _$ssr(_tmpl$);
@@ -511,10 +511,10 @@ function Foo() {
 exports[`rspack-esm (server, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -531,10 +531,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -551,10 +551,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:13",
@@ -574,10 +574,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -598,10 +598,10 @@ exports[`rspack-esm (server, non-hydratable) > FunctionDeclaration > should tran
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
@@ -658,11 +658,11 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -708,8 +708,8 @@ if (import.meta.webpackHot) {
 
 exports[`rspack-esm (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _$ssr(_tmpl$);
@@ -731,10 +731,10 @@ const Foo = () => {
 exports[`rspack-esm (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -751,10 +751,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -771,10 +771,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -794,10 +794,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -818,10 +818,10 @@ exports[`rspack-esm (server, non-hydratable) > VariableDeclarator > ArrowFunctio
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
@@ -878,11 +878,11 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -928,8 +928,8 @@ if (import.meta.webpackHot) {
 
 exports[`rspack-esm (server, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _$ssr(_tmpl$);
@@ -951,10 +951,10 @@ const Foo = function () {
 exports[`rspack-esm (server, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -971,10 +971,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -991,10 +991,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1014,10 +1014,10 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1038,10 +1038,10 @@ exports[`rspack-esm (server, non-hydratable) > VariableDeclarator > FunctionExpr
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
@@ -1098,11 +1098,11 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",

--- a/tests/server/__snapshots__/standard.test.ts.snap
+++ b/tests/server/__snapshots__/standard.test.ts.snap
@@ -33,8 +33,8 @@ if (module.hot) {
 
 exports[`standard (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _$ssr(_tmpl$);
@@ -56,10 +56,10 @@ export default function Foo() {
 exports[`standard (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -76,10 +76,10 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -96,10 +96,10 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -120,10 +120,10 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -145,10 +145,10 @@ exports[`standard (server, non-hydratable) > ExportDefaultDeclaration w/ Functio
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -207,11 +207,11 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>foo</div>",
+  _tmpl$2 = "<div>bar</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>foo</div>",
-  _tmpl$2 = "<div>bar</div>";
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:8:12",
@@ -258,8 +258,8 @@ if (module.hot) {
 
 exports[`standard (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _$ssr(_tmpl$);
@@ -281,10 +281,10 @@ export function Foo() {
 exports[`standard (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -305,10 +305,10 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -325,10 +325,10 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -349,10 +349,10 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -374,10 +374,10 @@ exports[`standard (server, non-hydratable) > ExportNamedDeclaration w/ FunctionE
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -436,11 +436,11 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>foo</div>",
+  _tmpl$2 = "<div>bar</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>foo</div>",
-  _tmpl$2 = "<div>bar</div>";
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:8:12",
@@ -488,8 +488,8 @@ if (module.hot) {
 
 exports[`standard (server, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _$ssr(_tmpl$);
@@ -511,10 +511,10 @@ function Foo() {
 exports[`standard (server, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -531,10 +531,10 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -551,10 +551,10 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:13",
@@ -574,10 +574,10 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -598,10 +598,10 @@ exports[`standard (server, non-hydratable) > FunctionDeclaration > should transf
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
@@ -658,11 +658,11 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -708,8 +708,8 @@ if (module.hot) {
 
 exports[`standard (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _$ssr(_tmpl$);
@@ -731,10 +731,10 @@ const Foo = () => {
 exports[`standard (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -751,10 +751,10 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -771,10 +771,10 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -794,10 +794,10 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -818,10 +818,10 @@ exports[`standard (server, non-hydratable) > VariableDeclarator > ArrowFunctionE
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
@@ -878,11 +878,11 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -928,8 +928,8 @@ if (module.hot) {
 
 exports[`standard (server, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _$ssr(_tmpl$);
@@ -951,10 +951,10 @@ const Foo = function () {
 exports[`standard (server, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -971,10 +971,10 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -991,10 +991,10 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1014,10 +1014,10 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1038,10 +1038,10 @@ exports[`standard (server, non-hydratable) > VariableDeclarator > FunctionExpres
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
@@ -1098,11 +1098,11 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",

--- a/tests/server/__snapshots__/vite.test.ts.snap
+++ b/tests/server/__snapshots__/vite.test.ts.snap
@@ -35,8 +35,8 @@ if (import.meta.hot) {
 
 exports[`vite (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _$ssr(_tmpl$);
@@ -59,10 +59,10 @@ export default function Foo() {
 exports[`vite (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -80,10 +80,10 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -101,10 +101,10 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -126,10 +126,10 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -152,10 +152,10 @@ exports[`vite (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExp
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -216,11 +216,11 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>foo</div>",
+  _tmpl$2 = "<div>bar</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>foo</div>",
-  _tmpl$2 = "<div>bar</div>";
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:8:12",
@@ -268,8 +268,8 @@ if (import.meta.hot) {
 
 exports[`vite (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _$ssr(_tmpl$);
@@ -292,10 +292,10 @@ export function Foo() {
 exports[`vite (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -317,10 +317,10 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -338,10 +338,10 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -363,10 +363,10 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -389,10 +389,10 @@ exports[`vite (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -453,11 +453,11 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>foo</div>",
+  _tmpl$2 = "<div>bar</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>foo</div>",
-  _tmpl$2 = "<div>bar</div>";
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:8:12",
@@ -506,8 +506,8 @@ if (import.meta.hot) {
 
 exports[`vite (server, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _$ssr(_tmpl$);
@@ -530,10 +530,10 @@ function Foo() {
 exports[`vite (server, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -551,10 +551,10 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -572,10 +572,10 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:13",
@@ -596,10 +596,10 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -621,10 +621,10 @@ exports[`vite (server, non-hydratable) > FunctionDeclaration > should transform 
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
@@ -683,11 +683,11 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -734,8 +734,8 @@ if (import.meta.hot) {
 
 exports[`vite (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _$ssr(_tmpl$);
@@ -758,10 +758,10 @@ const Foo = () => {
 exports[`vite (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -779,10 +779,10 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -800,10 +800,10 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -824,10 +824,10 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -849,10 +849,10 @@ exports[`vite (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
@@ -911,11 +911,11 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -962,8 +962,8 @@ if (import.meta.hot) {
 
 exports[`vite (server, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _$ssr(_tmpl$);
@@ -986,10 +986,10 @@ const Foo = function () {
 exports[`vite (server, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1007,10 +1007,10 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1028,10 +1028,10 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1052,10 +1052,10 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1077,10 +1077,10 @@ exports[`vite (server, non-hydratable) > VariableDeclarator > FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
@@ -1139,11 +1139,11 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",

--- a/tests/server/__snapshots__/webpack5.test.ts.snap
+++ b/tests/server/__snapshots__/webpack5.test.ts.snap
@@ -33,8 +33,8 @@ if (import.meta.webpackHot) {
 
 exports[`webpack5 (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export default function Foo() {
   return _$ssr(_tmpl$);
@@ -56,10 +56,10 @@ export default function Foo() {
 exports[`webpack5 (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -76,10 +76,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should skip ExportDefaultDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -96,10 +96,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -120,10 +120,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -145,10 +145,10 @@ exports[`webpack5 (server, non-hydratable) > ExportDefaultDeclaration w/ Functio
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -207,11 +207,11 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > ExportDefaultDeclaration w/ FunctionExpression > should transform ExportDefaultDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>foo</div>",
+  _tmpl$2 = "<div>bar</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>foo</div>",
-  _tmpl$2 = "<div>bar</div>";
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:8:12",
@@ -258,8 +258,8 @@ if (import.meta.webpackHot) {
 
 exports[`webpack5 (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 export function Foo() {
   return _$ssr(_tmpl$);
@@ -281,10 +281,10 @@ export function Foo() {
 exports[`webpack5 (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -305,10 +305,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should skip ExportNamedDeclaration w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -325,10 +325,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -349,10 +349,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -374,10 +374,10 @@ exports[`webpack5 (server, non-hydratable) > ExportNamedDeclaration w/ FunctionE
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -436,11 +436,11 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>foo</div>",
+  _tmpl$2 = "<div>bar</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>foo</div>",
-  _tmpl$2 = "<div>bar</div>";
 const _REGISTRY = _$$registry();
 const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:8:12",
@@ -488,8 +488,8 @@ if (import.meta.webpackHot) {
 
 exports[`webpack5 (server, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 function Foo() {
   return _$ssr(_tmpl$);
@@ -511,10 +511,10 @@ function Foo() {
 exports[`webpack5 (server, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -531,10 +531,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > FunctionDeclaration > should skip FunctionDeclaration with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -551,10 +551,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:13",
@@ -574,10 +574,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -598,10 +598,10 @@ exports[`webpack5 (server, non-hydratable) > FunctionDeclaration > should transf
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
@@ -658,11 +658,11 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
@@ -708,8 +708,8 @@ if (import.meta.webpackHot) {
 
 exports[`webpack5 (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = () => {
   return _$ssr(_tmpl$);
@@ -731,10 +731,10 @@ const Foo = () => {
 exports[`webpack5 (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -751,10 +751,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should skip VariableDeclarator w/ ArrowFunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -771,10 +771,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -794,10 +794,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -818,10 +818,10 @@ exports[`webpack5 (server, non-hydratable) > VariableDeclarator > ArrowFunctionE
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
@@ -878,11 +878,11 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > VariableDeclarator > ArrowFunctionExpression > should transform VariableDeclarator w/ ArrowFunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -928,8 +928,8 @@ if (import.meta.webpackHot) {
 
 exports[`webpack5 (server, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with @refresh reload 1`] = `
 "import { ssr as _$ssr } from "solid-js/web";
-import { $$decline as _$$decline } from "solid-refresh";
 var _tmpl$ = "<h1>Foo</h1>";
+import { $$decline as _$$decline } from "solid-refresh";
 // @refresh reload
 const Foo = function () {
   return _$ssr(_tmpl$);
@@ -951,10 +951,10 @@ const Foo = function () {
 exports[`webpack5 (server, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with invalid Component name 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const JSX_foo_1 = _$$component(_REGISTRY, "JSX_foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -971,10 +971,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > VariableDeclarator > FunctionExpression > should skip VariableDeclarator w/ FunctionExpression with valid Component name and >1 params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -991,10 +991,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 1`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1014,10 +1014,10 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 2`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<h1>Foo</h1>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<h1>Foo</h1>";
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",
@@ -1038,10 +1038,10 @@ exports[`webpack5 (server, non-hydratable) > VariableDeclarator > FunctionExpres
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { escape as _$escape } from "solid-js/web";
+var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = ["<h1>", "</h1>"];
 const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
@@ -1098,11 +1098,11 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > VariableDeclarator > FunctionExpression > should transform VariableDeclarator w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
 const _REGISTRY = _$$registry();
 const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:17",


### PR DESCRIPTION
This PR focuses more on correcting bindings that are lost during the transformation process. Things like new functions, new variable declarations and new imports can cause issues with other babel plugins.

This involves:
- Removing `@babel/helper-module-imports`.
  - The package is unnecessary bloat that can be simplified with a few lines. On top of that, the package doesn't correct bindings for new imports. 
- Remove unnecessary scope crawling.
  - This was a naive solution, but I found out that `insertBefore` and `replaceWith` returns a new path. With that in mind, we can register the replacement declarations immediately after insertion. So no need to re-crawl the entire scope.
  
Minor fix includes capturing the import declarations. The issue was that I initially added a check if the import is a normal import or a type import through `importKind === "value"`. Turns out that's not always true, so I did an inverse check instead.