### PR TITLE
fix: hmr support for hoisted functions

### DIFF
--- a/src/babel/index.ts
+++ b/src/babel/index.ts
@@ -309,10 +309,6 @@ function bubbleFunctionDeclaration(
       // have zero or one parameter
       decl.params.length < 2
     ) {
-      const first = program.get('body')[0];
-      const [tmp] = first.insertBefore(decl);
-      program.scope.registerDeclaration(tmp);
-      tmp.skip();
       if (path.parentPath.isExportNamedDeclaration()) {
         path.parentPath.replaceWith(
           t.exportNamedDeclaration(undefined, [
@@ -324,6 +320,9 @@ function bubbleFunctionDeclaration(
       } else {
         path.remove();
       }
+      const [tmp] = program.unshiftContainer('body', [decl]);
+      program.scope.registerDeclaration(tmp);
+      tmp.skip();
     }
   }
 }
@@ -361,6 +360,7 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
             bubbleFunctionDeclaration(programPath, path);
           },
         });
+        programPath.scope.crawl();
         if (state.jsx) {
           programPath.traverse({
             JSXElement(path) {
@@ -370,6 +370,7 @@ export default function solidRefreshPlugin(): babel.PluginObj<State> {
               transformJSX(path);
             },
           });
+          programPath.scope.crawl();
         }
         programPath.traverse({
           VariableDeclarator(path) {

--- a/tests/client-hydratable/__snapshots__/esm.test.ts.snap
+++ b/tests/client-hydratable/__snapshots__/esm.test.ts.snap
@@ -451,48 +451,39 @@ exports[`esm (client, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -624,7 +615,6 @@ var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _$getNextElement(_tmpl$);
@@ -645,6 +635,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (import.meta.hot) {
   _$$refresh("esm", import.meta.hot, _REGISTRY);
 }"
@@ -655,7 +646,6 @@ exports[`esm (client, hydratable) > FunctionDeclaration > should transform Funct
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -676,6 +666,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (import.meta.hot) {
   _$$refresh("esm", import.meta.hot, _REGISTRY);
 }"
@@ -685,23 +676,13 @@ exports[`esm (client, hydratable) > FunctionDeclaration > should transform Funct
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -709,15 +690,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (import.meta.hot) {
   _$$refresh("esm", import.meta.hot, _REGISTRY);

--- a/tests/client-hydratable/__snapshots__/rspack-esm.test.ts.snap
+++ b/tests/client-hydratable/__snapshots__/rspack-esm.test.ts.snap
@@ -451,48 +451,39 @@ exports[`rspack-esm (client, hydratable) > ExportNamedDeclaration w/ FunctionExp
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -624,7 +615,6 @@ var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _$getNextElement(_tmpl$);
@@ -645,6 +635,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (import.meta.webpackHot) {
   _$$refresh("rspack-esm", import.meta.webpackHot, _REGISTRY);
 }"
@@ -655,7 +646,6 @@ exports[`rspack-esm (client, hydratable) > FunctionDeclaration > should transfor
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -676,6 +666,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (import.meta.webpackHot) {
   _$$refresh("rspack-esm", import.meta.webpackHot, _REGISTRY);
 }"
@@ -685,23 +676,13 @@ exports[`rspack-esm (client, hydratable) > FunctionDeclaration > should transfor
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -709,15 +690,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (import.meta.webpackHot) {
   _$$refresh("rspack-esm", import.meta.webpackHot, _REGISTRY);

--- a/tests/client-hydratable/__snapshots__/standard.test.ts.snap
+++ b/tests/client-hydratable/__snapshots__/standard.test.ts.snap
@@ -451,48 +451,39 @@ exports[`standard (client, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -624,7 +615,6 @@ var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _$getNextElement(_tmpl$);
@@ -645,6 +635,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (module.hot) {
   _$$refresh("standard", module.hot, _REGISTRY);
 }"
@@ -655,7 +646,6 @@ exports[`standard (client, hydratable) > FunctionDeclaration > should transform 
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -676,6 +666,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (module.hot) {
   _$$refresh("standard", module.hot, _REGISTRY);
 }"
@@ -685,23 +676,13 @@ exports[`standard (client, hydratable) > FunctionDeclaration > should transform 
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -709,15 +690,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (module.hot) {
   _$$refresh("standard", module.hot, _REGISTRY);

--- a/tests/client-hydratable/__snapshots__/vite.test.ts.snap
+++ b/tests/client-hydratable/__snapshots__/vite.test.ts.snap
@@ -464,48 +464,39 @@ exports[`vite (client, hydratable) > ExportNamedDeclaration w/ FunctionExpressio
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -641,7 +632,6 @@ var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _$getNextElement(_tmpl$);
@@ -662,6 +652,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (import.meta.hot) {
   import.meta.hot.accept();
   _$$refresh("vite", import.meta.hot, _REGISTRY);
@@ -673,7 +664,6 @@ exports[`vite (client, hydratable) > FunctionDeclaration > should transform Func
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -694,6 +684,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (import.meta.hot) {
   import.meta.hot.accept();
   _$$refresh("vite", import.meta.hot, _REGISTRY);
@@ -704,23 +695,13 @@ exports[`vite (client, hydratable) > FunctionDeclaration > should transform Func
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -728,15 +709,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (import.meta.hot) {
   import.meta.hot.accept();

--- a/tests/client-hydratable/__snapshots__/webpack5.test.ts.snap
+++ b/tests/client-hydratable/__snapshots__/webpack5.test.ts.snap
@@ -451,48 +451,39 @@ exports[`webpack5 (client, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -624,7 +615,6 @@ var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _$getNextElement(_tmpl$);
@@ -645,6 +635,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (import.meta.webpackHot) {
   _$$refresh("webpack5", import.meta.webpackHot, _REGISTRY);
 }"
@@ -655,7 +646,6 @@ exports[`webpack5 (client, hydratable) > FunctionDeclaration > should transform 
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -676,6 +666,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (import.meta.webpackHot) {
   _$$refresh("webpack5", import.meta.webpackHot, _REGISTRY);
 }"
@@ -685,23 +676,13 @@ exports[`webpack5 (client, hydratable) > FunctionDeclaration > should transform 
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
 import { getNextElement as _$getNextElement } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -709,15 +690,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$getNextElement(_tmpl$2), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (import.meta.webpackHot) {
   _$$refresh("webpack5", import.meta.webpackHot, _REGISTRY);

--- a/tests/client/__snapshots__/esm.test.ts.snap
+++ b/tests/client/__snapshots__/esm.test.ts.snap
@@ -435,48 +435,39 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_tmpl$2(), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$2(), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -601,7 +592,6 @@ var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _tmpl$();
@@ -622,6 +612,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (import.meta.hot) {
   _$$refresh("esm", import.meta.hot, _REGISTRY);
 }"
@@ -632,7 +623,6 @@ exports[`esm (client, non-hydratable) > FunctionDeclaration > should transform F
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -653,6 +643,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (import.meta.hot) {
   _$$refresh("esm", import.meta.hot, _REGISTRY);
 }"
@@ -661,23 +652,13 @@ if (import.meta.hot) {
 exports[`esm (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$2(), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -685,15 +666,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_tmpl$2(), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (import.meta.hot) {
   _$$refresh("esm", import.meta.hot, _REGISTRY);

--- a/tests/client/__snapshots__/rspack-esm.test.ts.snap
+++ b/tests/client/__snapshots__/rspack-esm.test.ts.snap
@@ -435,48 +435,39 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_tmpl$2(), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$2(), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -601,7 +592,6 @@ var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _tmpl$();
@@ -622,6 +612,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (import.meta.webpackHot) {
   _$$refresh("rspack-esm", import.meta.webpackHot, _REGISTRY);
 }"
@@ -632,7 +623,6 @@ exports[`rspack-esm (client, non-hydratable) > FunctionDeclaration > should tran
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -653,6 +643,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (import.meta.webpackHot) {
   _$$refresh("rspack-esm", import.meta.webpackHot, _REGISTRY);
 }"
@@ -661,23 +652,13 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$2(), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -685,15 +666,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_tmpl$2(), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (import.meta.webpackHot) {
   _$$refresh("rspack-esm", import.meta.webpackHot, _REGISTRY);

--- a/tests/client/__snapshots__/standard.test.ts.snap
+++ b/tests/client/__snapshots__/standard.test.ts.snap
@@ -435,48 +435,39 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_tmpl$2(), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$2(), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -601,7 +592,6 @@ var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _tmpl$();
@@ -622,6 +612,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (module.hot) {
   _$$refresh("standard", module.hot, _REGISTRY);
 }"
@@ -632,7 +623,6 @@ exports[`standard (client, non-hydratable) > FunctionDeclaration > should transf
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -653,6 +643,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (module.hot) {
   _$$refresh("standard", module.hot, _REGISTRY);
 }"
@@ -661,23 +652,13 @@ if (module.hot) {
 exports[`standard (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$2(), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -685,15 +666,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_tmpl$2(), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (module.hot) {
   _$$refresh("standard", module.hot, _REGISTRY);

--- a/tests/client/__snapshots__/vite.test.ts.snap
+++ b/tests/client/__snapshots__/vite.test.ts.snap
@@ -448,48 +448,39 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_tmpl$2(), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$2(), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -618,7 +609,6 @@ var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _tmpl$();
@@ -639,6 +629,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (import.meta.hot) {
   import.meta.hot.accept();
   _$$refresh("vite", import.meta.hot, _REGISTRY);
@@ -650,7 +641,6 @@ exports[`vite (client, non-hydratable) > FunctionDeclaration > should transform 
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -671,6 +661,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (import.meta.hot) {
   import.meta.hot.accept();
   _$$refresh("vite", import.meta.hot, _REGISTRY);
@@ -680,23 +671,13 @@ if (import.meta.hot) {
 exports[`vite (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$2(), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -704,15 +685,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_tmpl$2(), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (import.meta.hot) {
   import.meta.hot.accept();

--- a/tests/client/__snapshots__/webpack5.test.ts.snap
+++ b/tests/client/__snapshots__/webpack5.test.ts.snap
@@ -435,48 +435,39 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_tmpl$2(), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$2(), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -601,7 +592,6 @@ var _tmpl$ = /*#__PURE__*/_$template(\`<h1>\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/(() => {
   var _el$ = _tmpl$();
@@ -622,6 +612,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (import.meta.webpackHot) {
   _$$refresh("webpack5", import.meta.webpackHot, _REGISTRY);
 }"
@@ -632,7 +623,6 @@ exports[`webpack5 (client, non-hydratable) > FunctionDeclaration > should transf
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -653,6 +643,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (import.meta.webpackHot) {
   _$$refresh("webpack5", import.meta.webpackHot, _REGISTRY);
 }"
@@ -661,23 +652,13 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (client, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { template as _$template } from "solid-js/web";
 import { createComponent as _$createComponent } from "solid-js/web";
-var _tmpl$ = /*#__PURE__*/_$template(\`<div>bar\`),
-  _tmpl$2 = /*#__PURE__*/_$template(\`<div>foo\`);
+var _tmpl$ = /*#__PURE__*/_$template(\`<div>foo\`),
+  _tmpl$2 = /*#__PURE__*/_$template(\`<div>bar\`);
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_tmpl$(), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$2(), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_tmpl$(), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -685,15 +666,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_tmpl$2(), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (import.meta.webpackHot) {
   _$$refresh("webpack5", import.meta.webpackHot, _REGISTRY);

--- a/tests/server-hydratable/__snapshots__/esm.test.ts.snap
+++ b/tests/server-hydratable/__snapshots__/esm.test.ts.snap
@@ -443,48 +443,39 @@ exports[`esm (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-var _tmpl$ = ["<div", ">foo</div>"],
-  _tmpl$2 = ["<div", ">bar</div>"];
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -616,7 +607,6 @@ var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -633,6 +623,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (import.meta.hot) {
   _$$refresh("esm", import.meta.hot, _REGISTRY);
 }"
@@ -643,7 +634,6 @@ exports[`esm (server, hydratable) > FunctionDeclaration > should transform Funct
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -664,6 +654,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (import.meta.hot) {
   _$$refresh("esm", import.meta.hot, _REGISTRY);
 }"
@@ -673,23 +664,13 @@ exports[`esm (server, hydratable) > FunctionDeclaration > should transform Funct
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
+var _tmpl$ = ["<div", ">foo</div>"],
+  _tmpl$2 = ["<div", ">bar</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -697,15 +678,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (import.meta.hot) {
   _$$refresh("esm", import.meta.hot, _REGISTRY);

--- a/tests/server-hydratable/__snapshots__/rspack-esm.test.ts.snap
+++ b/tests/server-hydratable/__snapshots__/rspack-esm.test.ts.snap
@@ -443,48 +443,39 @@ exports[`esm (server, hydratable) > ExportNamedDeclaration w/ FunctionExpression
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-var _tmpl$ = ["<div", ">foo</div>"],
-  _tmpl$2 = ["<div", ">bar</div>"];
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -616,7 +607,6 @@ var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -633,6 +623,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (import.meta.hot) {
   _$$refresh("esm", import.meta.hot, _REGISTRY);
 }"
@@ -643,7 +634,6 @@ exports[`esm (server, hydratable) > FunctionDeclaration > should transform Funct
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -664,6 +654,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (import.meta.hot) {
   _$$refresh("esm", import.meta.hot, _REGISTRY);
 }"
@@ -673,23 +664,13 @@ exports[`esm (server, hydratable) > FunctionDeclaration > should transform Funct
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
+var _tmpl$ = ["<div", ">foo</div>"],
+  _tmpl$2 = ["<div", ">bar</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -697,15 +678,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (import.meta.hot) {
   _$$refresh("esm", import.meta.hot, _REGISTRY);

--- a/tests/server-hydratable/__snapshots__/standard.test.ts.snap
+++ b/tests/server-hydratable/__snapshots__/standard.test.ts.snap
@@ -443,48 +443,39 @@ exports[`standard (server, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-var _tmpl$ = ["<div", ">foo</div>"],
-  _tmpl$2 = ["<div", ">bar</div>"];
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -616,7 +607,6 @@ var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -633,6 +623,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (module.hot) {
   _$$refresh("standard", module.hot, _REGISTRY);
 }"
@@ -643,7 +634,6 @@ exports[`standard (server, hydratable) > FunctionDeclaration > should transform 
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -664,6 +654,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (module.hot) {
   _$$refresh("standard", module.hot, _REGISTRY);
 }"
@@ -673,23 +664,13 @@ exports[`standard (server, hydratable) > FunctionDeclaration > should transform 
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
+var _tmpl$ = ["<div", ">foo</div>"],
+  _tmpl$2 = ["<div", ">bar</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -697,15 +678,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (module.hot) {
   _$$refresh("standard", module.hot, _REGISTRY);

--- a/tests/server-hydratable/__snapshots__/vite.test.ts.snap
+++ b/tests/server-hydratable/__snapshots__/vite.test.ts.snap
@@ -456,48 +456,39 @@ exports[`vite (server, hydratable) > ExportNamedDeclaration w/ FunctionExpressio
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-var _tmpl$ = ["<div", ">foo</div>"],
-  _tmpl$2 = ["<div", ">bar</div>"];
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -633,7 +624,6 @@ var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -650,6 +640,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (import.meta.hot) {
   import.meta.hot.accept();
   _$$refresh("vite", import.meta.hot, _REGISTRY);
@@ -661,7 +652,6 @@ exports[`vite (server, hydratable) > FunctionDeclaration > should transform Func
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -682,6 +672,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (import.meta.hot) {
   import.meta.hot.accept();
   _$$refresh("vite", import.meta.hot, _REGISTRY);
@@ -692,23 +683,13 @@ exports[`vite (server, hydratable) > FunctionDeclaration > should transform Func
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
+var _tmpl$ = ["<div", ">foo</div>"],
+  _tmpl$2 = ["<div", ">bar</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -716,15 +697,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (import.meta.hot) {
   import.meta.hot.accept();

--- a/tests/server-hydratable/__snapshots__/webpack5.test.ts.snap
+++ b/tests/server-hydratable/__snapshots__/webpack5.test.ts.snap
@@ -443,48 +443,39 @@ exports[`webpack5 (server, hydratable) > ExportNamedDeclaration w/ FunctionExpre
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-var _tmpl$ = ["<div", ">foo</div>"],
-  _tmpl$2 = ["<div", ">bar</div>"];
+var _tmpl$ = ["<div", ">bar</div>"],
+  _tmpl$2 = ["<div", ">foo</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -616,7 +607,6 @@ var _tmpl$ = ["<h1", ">", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey(), _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -633,6 +623,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (import.meta.webpackHot) {
   _$$refresh("webpack5", import.meta.webpackHot, _REGISTRY);
 }"
@@ -643,7 +634,6 @@ exports[`webpack5 (server, hydratable) > FunctionDeclaration > should transform 
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -664,6 +654,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (import.meta.webpackHot) {
   _$$refresh("webpack5", import.meta.webpackHot, _REGISTRY);
 }"
@@ -673,23 +664,13 @@ exports[`webpack5 (server, hydratable) > FunctionDeclaration > should transform 
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
 import { ssrHydrationKey as _$ssrHydrationKey } from "solid-js/web";
-var _tmpl$ = ["<div", ">bar</div>"],
-  _tmpl$2 = ["<div", ">foo</div>"];
+var _tmpl$ = ["<div", ">foo</div>"],
+  _tmpl$2 = ["<div", ">bar</div>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$ssrHydrationKey()), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -697,15 +678,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2, _$ssrHydrationKey()), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (import.meta.webpackHot) {
   _$$refresh("webpack5", import.meta.webpackHot, _REGISTRY);

--- a/tests/server/__snapshots__/esm.test.ts.snap
+++ b/tests/server/__snapshots__/esm.test.ts.snap
@@ -427,48 +427,39 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
-var _tmpl$ = "<div>foo</div>",
-  _tmpl$2 = "<div>bar</div>";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -593,7 +584,6 @@ var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -610,6 +600,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (import.meta.hot) {
   _$$refresh("esm", import.meta.hot, _REGISTRY);
 }"
@@ -620,7 +611,6 @@ exports[`esm (server, non-hydratable) > FunctionDeclaration > should transform F
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -641,6 +631,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (import.meta.hot) {
   _$$refresh("esm", import.meta.hot, _REGISTRY);
 }"
@@ -649,23 +640,13 @@ if (import.meta.hot) {
 exports[`esm (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
+var _tmpl$ = "<div>foo</div>",
+  _tmpl$2 = "<div>bar</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -673,15 +654,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (import.meta.hot) {
   _$$refresh("esm", import.meta.hot, _REGISTRY);

--- a/tests/server/__snapshots__/rspack-esm.test.ts.snap
+++ b/tests/server/__snapshots__/rspack-esm.test.ts.snap
@@ -427,48 +427,39 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
-var _tmpl$ = "<div>foo</div>",
-  _tmpl$2 = "<div>bar</div>";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -593,7 +584,6 @@ var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -610,6 +600,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (import.meta.webpackHot) {
   _$$refresh("rspack-esm", import.meta.webpackHot, _REGISTRY);
 }"
@@ -620,7 +611,6 @@ exports[`rspack-esm (server, non-hydratable) > FunctionDeclaration > should tran
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -641,6 +631,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (import.meta.webpackHot) {
   _$$refresh("rspack-esm", import.meta.webpackHot, _REGISTRY);
 }"
@@ -649,23 +640,13 @@ if (import.meta.webpackHot) {
 exports[`rspack-esm (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
+var _tmpl$ = "<div>foo</div>",
+  _tmpl$2 = "<div>bar</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -673,15 +654,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (import.meta.webpackHot) {
   _$$refresh("rspack-esm", import.meta.webpackHot, _REGISTRY);

--- a/tests/server/__snapshots__/standard.test.ts.snap
+++ b/tests/server/__snapshots__/standard.test.ts.snap
@@ -427,48 +427,39 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
-var _tmpl$ = "<div>foo</div>",
-  _tmpl$2 = "<div>bar</div>";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -593,7 +584,6 @@ var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -610,6 +600,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (module.hot) {
   _$$refresh("standard", module.hot, _REGISTRY);
 }"
@@ -620,7 +611,6 @@ exports[`standard (server, non-hydratable) > FunctionDeclaration > should transf
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -641,6 +631,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (module.hot) {
   _$$refresh("standard", module.hot, _REGISTRY);
 }"
@@ -649,23 +640,13 @@ if (module.hot) {
 exports[`standard (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
+var _tmpl$ = "<div>foo</div>",
+  _tmpl$2 = "<div>bar</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -673,15 +654,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (module.hot) {
   _$$refresh("standard", module.hot, _REGISTRY);

--- a/tests/server/__snapshots__/vite.test.ts.snap
+++ b/tests/server/__snapshots__/vite.test.ts.snap
@@ -440,48 +440,39 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
-var _tmpl$ = "<div>foo</div>",
-  _tmpl$2 = "<div>bar</div>";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -610,7 +601,6 @@ var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -627,6 +617,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (import.meta.hot) {
   import.meta.hot.accept();
   _$$refresh("vite", import.meta.hot, _REGISTRY);
@@ -638,7 +629,6 @@ exports[`vite (server, non-hydratable) > FunctionDeclaration > should transform 
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -659,6 +649,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (import.meta.hot) {
   import.meta.hot.accept();
   _$$refresh("vite", import.meta.hot, _REGISTRY);
@@ -668,23 +659,13 @@ if (import.meta.hot) {
 exports[`vite (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
+var _tmpl$ = "<div>foo</div>",
+  _tmpl$2 = "<div>bar</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -692,15 +673,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (import.meta.hot) {
   import.meta.hot.accept();

--- a/tests/server/__snapshots__/webpack5.test.ts.snap
+++ b/tests/server/__snapshots__/webpack5.test.ts.snap
@@ -427,48 +427,39 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > ExportNamedDeclaration w/ FunctionExpression > should transform ExportNamedDeclaration w/ FunctionExpression with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
-var _tmpl$ = "<div>foo</div>",
-  _tmpl$2 = "<div>bar</div>";
+var _tmpl$ = "<div>bar</div>",
+  _tmpl$2 = "<div>foo</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
-  location: "example.jsx:8:12",
-  signature: "241c14a4"
-});
-const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(_props4.v0, {}), {
-  location: "example.jsx:9:12",
-  signature: "9a24e06b"
-});
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {
-  get v0() {
-    return _props.v0;
-  }
-})], {
-  location: "example.jsx:7:10",
-  signature: "77f4a4b9"
-});
-const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
-  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {
-    v0: Bar
-  });
-}, {
-  location: "example.jsx:5:13",
-  signature: "2f861eed",
-  dependencies: () => ({
-    Bar
-  })
-});
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:3:15",
-  signature: "fad4daa8"
+  signature: "61dd3182"
 });
 const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
   return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
 }, {
   location: "example.jsx:2:13",
   signature: "e93ca257"
+});
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+  location: "example.jsx:8:12",
+  signature: "241c14a4"
+});
+const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-skip*/_$createComponent(Bar, {}), {
+  location: "example.jsx:9:12",
+  signature: "61d9a109"
+});
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+  location: "example.jsx:7:10",
+  signature: "5302828d"
+});
+const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
+  return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
+}, {
+  location: "example.jsx:5:13",
+  signature: "c963b907"
 });
 export { Bar };
 export { Foo };
@@ -593,7 +584,6 @@ var _tmpl$ = ["<h1>", "</h1>"];
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const example = 'Foo';
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$, _$escape(_props.v0)), {
   location: "example.jsx:4:15",
@@ -610,6 +600,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     example
   })
 });
+const example = 'Foo';
 if (import.meta.webpackHot) {
   _$$refresh("webpack5", import.meta.webpackHot, _REGISTRY);
 }"
@@ -620,7 +611,6 @@ exports[`webpack5 (server, non-hydratable) > FunctionDeclaration > should transf
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
-const Example = createContext();
 const _REGISTRY = _$$registry();
 const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/_$createComponent(_props.v0, {
   children: "Foo"
@@ -641,6 +631,7 @@ const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
     Example
   })
 });
+const Example = createContext();
 if (import.meta.webpackHot) {
   _$$refresh("webpack5", import.meta.webpackHot, _REGISTRY);
 }"
@@ -649,23 +640,13 @@ if (import.meta.webpackHot) {
 exports[`webpack5 (server, non-hydratable) > FunctionDeclaration > should transform FunctionDeclaration with valid Component name and params 5`] = `
 "import { createComponent as _$createComponent } from "solid-js/web";
 import { ssr as _$ssr } from "solid-js/web";
-var _tmpl$ = "<div>bar</div>",
-  _tmpl$2 = "<div>foo</div>";
+var _tmpl$ = "<div>foo</div>",
+  _tmpl$2 = "<div>bar</div>";
 import { $$component as _$$component } from "solid-refresh";
 import { $$refresh as _$$refresh } from "solid-refresh";
 import { $$registry as _$$registry } from "solid-refresh";
 const _REGISTRY = _$$registry();
-const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
-  location: "example.jsx:3:15",
-  signature: "61dd3182"
-});
-const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
-  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
-}, {
-  location: "example.jsx:2:6",
-  signature: "e93ca257"
-});
-const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+const Foo_1_1 = _$$component(_REGISTRY, "Foo_1_1", _props3 => /*@refresh jsx-skip*/_$ssr(_tmpl$), {
   location: "example.jsx:8:12",
   signature: "241c14a4"
 });
@@ -673,15 +654,25 @@ const Foo_1_2 = _$$component(_REGISTRY, "Foo_1_2", _props4 => /*@refresh jsx-ski
   location: "example.jsx:9:12",
   signature: "61d9a109"
 });
-const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props2 => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
+const Foo_1 = _$$component(_REGISTRY, "Foo_1", _props => /*@refresh jsx-skip*/[_$createComponent(Foo_1_1, {}), _$createComponent(Foo_1_2, {})], {
   location: "example.jsx:7:10",
-  signature: "5302828d"
+  signature: "825a754d"
 });
 const Foo = _$$component(_REGISTRY, "Foo", function Foo() {
   return /*@refresh jsx-skip*/_$createComponent(Foo_1, {});
 }, {
   location: "example.jsx:5:6",
   signature: "c963b907"
+});
+const Bar_1 = _$$component(_REGISTRY, "Bar_1", _props2 => /*@refresh jsx-skip*/_$ssr(_tmpl$2), {
+  location: "example.jsx:3:15",
+  signature: "fad4daa8"
+});
+const Bar = _$$component(_REGISTRY, "Bar", function Bar() {
+  return /*@refresh jsx-skip*/_$createComponent(Bar_1, {});
+}, {
+  location: "example.jsx:2:6",
+  signature: "e93ca257"
 });
 if (import.meta.webpackHot) {
   _$$refresh("webpack5", import.meta.webpackHot, _REGISTRY);


### PR DESCRIPTION
hoisted functions remained in place rather than moving to top, which yielded errors. This PR ensures that the functions are moved to top.